### PR TITLE
bug : healthcheak endpoint가 token filter에 막혀 403 리턴하는 것을 수정

### DIFF
--- a/src/main/java/com/omegafrog/My/piano/app/security/filter/CommonUserJwtTokenFilter.java
+++ b/src/main/java/com/omegafrog/My/piano/app/security/filter/CommonUserJwtTokenFilter.java
@@ -61,7 +61,9 @@ public class CommonUserJwtTokenFilter extends OncePerRequestFilter {
                         AntPathRequestMatcher.antMatcher("/h2-console/**"),
                         AntPathRequestMatcher.antMatcher("/oauth2/**"),
                         AntPathRequestMatcher.antMatcher("/revalidate"),
-                        AntPathRequestMatcher.antMatcher("/api/v1/popular")
+                        AntPathRequestMatcher.antMatcher("/api/v1/popular"),
+                        AntPathRequestMatcher.antMatcher("/healthcheak")
+
                 ));
         for (AntPathRequestMatcher pathMatcher : ignoredPatterns) {
             if (pathMatcher.matches(request)) {


### PR DESCRIPTION
commonUserjwtTokenFilter의 통과 rule에 /healthcheak 추가