### PR TITLE
fix: SheetPost outbox 완료 시점을 Elasticsearch 반영 성공 기준으로 보장

### DIFF
--- a/src/main/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchInstance.java
+++ b/src/main/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchInstance.java
@@ -56,11 +56,19 @@ public class ElasticSearchInstance {
 
     @Async("ThreadPoolTaskExecutor")
     public void invertIndexingSheetPost(SheetPost sheetPost) {
+        saveSheetPostIndex(sheetPost);
+    }
+
+    public void saveSheetPostIndex(SheetPost sheetPost) {
         sheetPostIndexRepository.save(SheetPostIndex.of(sheetPost));
     }
 
     @Async("ThreadPoolTaskExecutor")
     public void invertIndexingSheetPost(SheetPostIndex index) {
+        saveSheetPostIndex(index);
+    }
+
+    public void saveSheetPostIndex(SheetPostIndex index) {
         sheetPostIndexRepository.save(index);
     }
 

--- a/src/main/java/com/omegafrog/My/piano/app/web/service/outbox/SheetPostOutboxProcessor.java
+++ b/src/main/java/com/omegafrog/My/piano/app/web/service/outbox/SheetPostOutboxProcessor.java
@@ -82,7 +82,7 @@ public class SheetPostOutboxProcessor {
                 SheetPost sheetPost = sheetPostRepository.findById(event.getSheetPostId())
                         .orElseThrow(() -> new EntityNotFoundException(
                                 "Cannot find sheet post. id=" + event.getSheetPostId()));
-                elasticSearchInstance.invertIndexingSheetPost(sheetPost);
+                elasticSearchInstance.saveSheetPostIndex(sheetPost);
             }
             event.markCompleted(now);
         } catch (Exception e) {

--- a/src/test/java/com/omegafrog/My/piano/app/web/service/outbox/SheetPostOutboxProcessorTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/web/service/outbox/SheetPostOutboxProcessorTest.java
@@ -1,0 +1,94 @@
+package com.omegafrog.My.piano.app.web.service.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.omegafrog.My.piano.app.external.elasticsearch.ElasticSearchInstance;
+import com.omegafrog.My.piano.app.web.domain.outbox.SheetPostOutboxEvent;
+import com.omegafrog.My.piano.app.web.domain.outbox.SheetPostOutboxEventRepository;
+import com.omegafrog.My.piano.app.web.domain.outbox.SheetPostOutboxEventStatus;
+import com.omegafrog.My.piano.app.web.domain.outbox.SheetPostOutboxEventType;
+import com.omegafrog.My.piano.app.web.domain.sheet.SheetPost;
+import com.omegafrog.My.piano.app.web.domain.sheet.SheetPostRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SheetPostOutboxProcessorTest {
+
+    @Mock
+    private SheetPostOutboxEventRepository outboxRepository;
+    @Mock
+    private SheetPostRepository sheetPostRepository;
+    @Mock
+    private ElasticSearchInstance elasticSearchInstance;
+
+    private SheetPostOutboxProcessor processor;
+
+    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-02-12T00:00:00Z"), ZoneOffset.UTC);
+
+    @BeforeEach
+    void setUp() {
+        processor = new SheetPostOutboxProcessor(
+                outboxRepository,
+                sheetPostRepository,
+                elasticSearchInstance,
+                fixedClock,
+                100,
+                Duration.ofMinutes(1));
+    }
+
+    @Test
+    @DisplayName("생성 이벤트는 Elasticsearch 저장 성공 후에만 완료 처리한다")
+    void completeCreatedEventAfterSuccessfulIndexing() {
+        SheetPostOutboxEvent event = SheetPostOutboxEvent.pending("evt-1", 10L, SheetPostOutboxEventType.SHEET_POST_CREATED);
+        SheetPost sheetPost = org.mockito.Mockito.mock(SheetPost.class);
+
+        when(outboxRepository.findProcessable(any(LocalDateTime.class), anyInt())).thenReturn(List.of(event));
+        when(sheetPostRepository.findById(10L)).thenReturn(Optional.of(sheetPost));
+
+        processor.processPendingEvents();
+
+        assertThat(event.getStatus()).isEqualTo(SheetPostOutboxEventStatus.COMPLETED);
+        verify(elasticSearchInstance).saveSheetPostIndex(sheetPost);
+    }
+
+    @Test
+    @DisplayName("Elasticsearch 저장 실패 시 completed 처리하지 않고 재시도 가능 상태로 남긴다")
+    void markFailedWhenIndexingThrows() {
+        SheetPostOutboxEvent event = SheetPostOutboxEvent.pending("evt-2", 20L, SheetPostOutboxEventType.SHEET_POST_CREATED);
+        SheetPost sheetPost = org.mockito.Mockito.mock(SheetPost.class);
+
+        when(outboxRepository.findProcessable(any(LocalDateTime.class), anyInt())).thenReturn(List.of(event));
+        when(sheetPostRepository.findById(20L)).thenReturn(Optional.of(sheetPost));
+        doThrow(new RuntimeException("es timeout")).when(elasticSearchInstance).saveSheetPostIndex(sheetPost);
+
+        processor.processPendingEvents();
+
+        assertThat(event.getStatus()).isEqualTo(SheetPostOutboxEventStatus.FAILED);
+        assertThat(event.getRetryCount()).isEqualTo(1);
+        assertThat(event.getProcessedAt()).isNull();
+        assertThat(event.getNextAttemptAt())
+                .isEqualTo(LocalDateTime.ofInstant(fixedClock.instant(), ZoneOffset.UTC).plusMinutes(1));
+        verify(elasticSearchInstance).saveSheetPostIndex(sheetPost);
+        verify(outboxRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## 변경 배경
- 관련 이슈: Closes #92
- `SheetPostOutboxProcessor`가 Elasticsearch 반영을 비동기 메서드에 위임한 직후 outbox event를 `COMPLETED`로 마킹하고 있었습니다.
- 이 구조에서는 실제 Elasticsearch 저장이 나중에 실패해도 outbox는 이미 완료 처리되어 재시도가 불가능했습니다.
- 결과적으로 DB와 검색 read model 사이에 조용한 정합성 붕괴가 생길 수 있어 우선 수정이 필요했습니다.

## 주요 변경사항
- `ElasticSearchInstance`에 동기 저장용 `saveSheetPostIndex(...)` 메서드를 추가했습니다.
- 기존 비동기 `invertIndexingSheetPost(...)`는 새 동기 메서드에 위임하도록 정리했습니다.
- `SheetPostOutboxProcessor`는 더 이상 비동기 인덱싱 메서드를 호출하지 않고, 동기 저장 성공 후에만 `markCompleted(...)` 하도록 변경했습니다.
- `SheetPostOutboxProcessorTest`를 추가해 다음 회귀 시나리오를 검증했습니다.
  - Elasticsearch 저장 성공 시에만 completed 처리
  - Elasticsearch 저장 실패 시 failed 처리 및 retry 정보 기록

## Implementation intent
Guarantee that `SheetPost` outbox completion means the Elasticsearch projection was actually written successfully.

## Implementation approach
- Split the sheet-post indexing entrypoint into synchronous `saveSheetPostIndex(...)` methods inside `ElasticSearchInstance`.
- Keep the existing async API for non-outbox callers, but make it delegate to the same synchronous save path.
- Change `SheetPostOutboxProcessor` to call the synchronous save method directly inside the processor transaction flow.
- Because the save now happens before `markCompleted(...)`, any indexing exception keeps the event on the failure/retry path instead of silently acknowledging it.

## Verification method
- `bash ./gradlew test --tests com.omegafrog.My.piano.app.web.service.outbox.SheetPostOutboxProcessorTest`
  - 성공: 신규 회귀 테스트 통과
- `bash ./gradlew build`
  - 실패: 본 변경과 무관한 기존 캐시/Ehcache 테스트 실패 확인
  - 실패 테스트
    - `EhcacheSmokeTest`
    - `EhcacheTtlContractTest`
    - `JCacheCacheManagerOverrideIntegrationTest`
    - `SheetPostCacheWarmupJobIntegrationTest`

## 테스트/검증 결과
- outbox 성공/실패 분기 자체는 신규 테스트로 검증했습니다.
- 전체 build gate는 기존 실패 테스트 때문에 green 상태는 아니었습니다.
- 이번 변경에서 추가로 발생한 컴파일 오류나 sheet-post outbox 관련 테스트 실패는 확인되지 않았습니다.

## 영향 범위 및 리스크
- 영향 범위는 `SheetPost` outbox 처리 경로와 Elasticsearch 저장 진입점에 한정됩니다.
- 장점: outbox completed 의미가 실제 projection 반영 성공과 일치합니다.
- 남은 리스크:
  - `update/delete` 경로는 아직 outbox로 완전히 통일되지 않았습니다.
  - 인덱스 alias, 검색 순서 보존, query/filter 개선 등은 후속 이슈에서 계속 처리해야 합니다.
