### PR TITLE
fix: SheetPost 수정/삭제 인덱싱 경로를 outbox로 통일

### DIFF
--- a/src/main/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchInstance.java
+++ b/src/main/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchInstance.java
@@ -72,6 +72,10 @@ public class ElasticSearchInstance {
         sheetPostIndexRepository.save(index);
     }
 
+    public void deleteSheetPostIndex(Long sheetPostId) {
+        sheetPostIndexRepository.deleteById(sheetPostId);
+    }
+
     public Pair<Page<Long>, String> searchSheetPost(@Nullable String searchSentence,
             @Nullable List<String> instruments,
             @Nullable List<String> difficulties,

--- a/src/main/java/com/omegafrog/My/piano/app/web/domain/outbox/SheetPostOutboxEventType.java
+++ b/src/main/java/com/omegafrog/My/piano/app/web/domain/outbox/SheetPostOutboxEventType.java
@@ -1,5 +1,7 @@
 package com.omegafrog.My.piano.app.web.domain.outbox;
 
 public enum SheetPostOutboxEventType {
-    SHEET_POST_CREATED
+    SHEET_POST_CREATED,
+    SHEET_POST_UPDATED,
+    SHEET_POST_DELETED
 }

--- a/src/main/java/com/omegafrog/My/piano/app/web/service/SheetPostApplicationService.java
+++ b/src/main/java/com/omegafrog/My/piano/app/web/service/SheetPostApplicationService.java
@@ -25,7 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.omegafrog.My.piano.app.external.elasticsearch.ElasticSearchInstance;
 import com.omegafrog.My.piano.app.external.elasticsearch.SheetPostIndex;
-import com.omegafrog.My.piano.app.external.elasticsearch.SheetPostIndexRepository;
 import com.omegafrog.My.piano.app.utils.AuthenticationUtil;
 import com.omegafrog.My.piano.app.utils.MapperUtil;
 import com.omegafrog.My.piano.app.web.domain.FileStorageExecutor;
@@ -59,8 +58,6 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 @Slf4j
 public class SheetPostApplicationService {
-	private final SheetPostIndexRepository sheetPostIndexRepository;
-
 	private final SheetPostRepository sheetPostRepository;
 	private final UserRepository userRepository;
 
@@ -209,7 +206,7 @@ public class SheetPostApplicationService {
 
 		// SheetPost 업데이트 (기본 정보: title, content, price 등)
 		SheetPost updated = sheetPost.update(dto);
-		elasticSearchInstance.invertIndexingSheetPost(updated);
+		sheetPostOutboxService.enqueueUpdated(updated.getId());
 		sheetPostCacheCoordinator.evictSheetPostListCache();
 		sheetPostCacheCoordinator.evictSheetPostDetailCache(id);
 		return updated.toDto();
@@ -231,12 +228,12 @@ public class SheetPostApplicationService {
 		User loggedInUser = authenticationUtil.getLoggedInUser();
 		SheetPost sheetPost = sheetPostRepository.findById(id)
 				.orElseThrow(() -> new EntityNotFoundException("Cannot find sheet post entity : " + id));
-		uploadFileExecutor.removeSheetPost(sheetPost);
-		sheetPostIndexRepository.deleteById(id);
-		if (sheetPost.getAuthor().equals(loggedInUser))
-			sheetPostRepository.deleteById(sheetPost.getId());
-		else
+		if (!sheetPost.getAuthor().equals(loggedInUser)) {
 			throw new AccessDeniedException("Cannot delete other user's sheet post entity : " + id);
+		}
+		uploadFileExecutor.removeSheetPost(sheetPost);
+		sheetPostRepository.deleteById(sheetPost.getId());
+		sheetPostOutboxService.enqueueDeleted(sheetPost.getId());
 		sheetPostCacheCoordinator.evictSheetPostListCache();
 		sheetPostCacheCoordinator.evictSheetPostDetailCache(id);
 	}

--- a/src/main/java/com/omegafrog/My/piano/app/web/service/outbox/SheetPostOutboxProcessor.java
+++ b/src/main/java/com/omegafrog/My/piano/app/web/service/outbox/SheetPostOutboxProcessor.java
@@ -78,12 +78,7 @@ public class SheetPostOutboxProcessor {
         LocalDateTime now = now();
 
         try {
-            if (event.getEventType() == SheetPostOutboxEventType.SHEET_POST_CREATED) {
-                SheetPost sheetPost = sheetPostRepository.findById(event.getSheetPostId())
-                        .orElseThrow(() -> new EntityNotFoundException(
-                                "Cannot find sheet post. id=" + event.getSheetPostId()));
-                elasticSearchInstance.saveSheetPostIndex(sheetPost);
-            }
+            applyToElastic(event);
             event.markCompleted(now);
         } catch (Exception e) {
             log.error(
@@ -93,6 +88,18 @@ public class SheetPostOutboxProcessor {
                     e);
             event.markFailed(e.getMessage(), now.plus(retryDelay));
         }
+    }
+
+    private void applyToElastic(SheetPostOutboxEvent event) {
+        if (event.getEventType() == SheetPostOutboxEventType.SHEET_POST_DELETED) {
+            elasticSearchInstance.deleteSheetPostIndex(event.getSheetPostId());
+            return;
+        }
+
+        SheetPost sheetPost = sheetPostRepository.findById(event.getSheetPostId())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Cannot find sheet post. id=" + event.getSheetPostId()));
+        elasticSearchInstance.saveSheetPostIndex(sheetPost);
     }
 
     private LocalDateTime now() {

--- a/src/main/java/com/omegafrog/My/piano/app/web/service/outbox/SheetPostOutboxService.java
+++ b/src/main/java/com/omegafrog/My/piano/app/web/service/outbox/SheetPostOutboxService.java
@@ -19,11 +19,25 @@ public class SheetPostOutboxService {
 
     @Transactional
     public void enqueueCreated(Long sheetPostId) {
+        enqueue(sheetPostId, SheetPostOutboxEventType.SHEET_POST_CREATED);
+    }
+
+    @Transactional
+    public void enqueueUpdated(Long sheetPostId) {
+        enqueue(sheetPostId, SheetPostOutboxEventType.SHEET_POST_UPDATED);
+    }
+
+    @Transactional
+    public void enqueueDeleted(Long sheetPostId) {
+        enqueue(sheetPostId, SheetPostOutboxEventType.SHEET_POST_DELETED);
+    }
+
+    private void enqueue(Long sheetPostId, SheetPostOutboxEventType eventType) {
         String eventId = UUID.randomUUID().toString();
         SheetPostOutboxEvent event = SheetPostOutboxEvent.pending(
                 eventId,
                 sheetPostId,
-                SheetPostOutboxEventType.SHEET_POST_CREATED);
+                eventType);
         sheetPostOutboxEventRepository.save(event);
     }
 }

--- a/src/test/java/com/omegafrog/My/piano/app/cache/SheetPostCachePerformanceCharacterizationTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/cache/SheetPostCachePerformanceCharacterizationTest.java
@@ -172,7 +172,6 @@ class SheetPostCachePerformanceCharacterizationTest {
         );
 
         return new SheetPostApplicationService(
-                sheetPostIndexRepository,
                 sheetPostRepository,
                 userRepository,
                 elasticSearchInstance,

--- a/src/test/java/com/omegafrog/My/piano/app/cache/SheetPostCacheWarmupServiceTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/cache/SheetPostCacheWarmupServiceTest.java
@@ -91,7 +91,6 @@ class SheetPostCacheWarmupServiceTest {
         sheetPostCacheCoordinator = new SheetPostCacheCoordinator(cacheManager, singleFlightCoordinator, executorProvider);
 
         service = new SheetPostApplicationService(
-                sheetPostIndexRepository,
                 sheetPostRepository,
                 userRepository,
                 elasticSearchInstance,

--- a/src/test/java/com/omegafrog/My/piano/app/cache/SheetPostSWRSingleFlightServiceTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/cache/SheetPostSWRSingleFlightServiceTest.java
@@ -97,7 +97,6 @@ class SheetPostSWRSingleFlightServiceTest {
         sheetPostCacheCoordinator = new SheetPostCacheCoordinator(cacheManager, new SingleFlightCoordinator(), executorProvider);
 
         service = new SheetPostApplicationService(
-                sheetPostIndexRepository,
                 sheetPostRepository,
                 userRepository,
                 elasticSearchInstance,

--- a/src/test/java/com/omegafrog/My/piano/app/web/service/SheetPostApplicationServiceOutboxTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/web/service/SheetPostApplicationServiceOutboxTest.java
@@ -1,0 +1,139 @@
+package com.omegafrog.My.piano.app.web.service;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.omegafrog.My.piano.app.external.elasticsearch.ElasticSearchInstance;
+import com.omegafrog.My.piano.app.utils.AuthenticationUtil;
+import com.omegafrog.My.piano.app.web.domain.FileStorageExecutor;
+import com.omegafrog.My.piano.app.web.domain.article.LikeCountRepository;
+import com.omegafrog.My.piano.app.web.domain.sheet.SheetPost;
+import com.omegafrog.My.piano.app.web.domain.sheet.SheetPostRepository;
+import com.omegafrog.My.piano.app.web.domain.sheet.SheetPostViewCountRepository;
+import com.omegafrog.My.piano.app.web.domain.user.User;
+import com.omegafrog.My.piano.app.web.domain.user.UserRepository;
+import com.omegafrog.My.piano.app.web.dto.sheetPost.UpdateSheetPostDto;
+import com.omegafrog.My.piano.app.web.service.cache.SheetPostCacheCoordinator;
+import com.omegafrog.My.piano.app.web.service.outbox.SheetPostOutboxService;
+
+@ExtendWith(MockitoExtension.class)
+class SheetPostApplicationServiceOutboxTest {
+
+    @Mock
+    private SheetPostRepository sheetPostRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ElasticSearchInstance elasticSearchInstance;
+    @Mock
+    private FileStorageExecutor fileStorageExecutor;
+    @Mock
+    private SheetPostViewCountRepository sheetPostViewCountRepository;
+    @Mock
+    private AuthenticationUtil authenticationUtil;
+    @Mock
+    private FileUploadService fileUploadService;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+    @Mock
+    private SheetPostOutboxService sheetPostOutboxService;
+    @Mock
+    private SheetPostCacheCoordinator sheetPostCacheCoordinator;
+    @Mock
+    private LikeCountRepository likeCountRepository;
+
+    private SheetPostApplicationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SheetPostApplicationService(
+                sheetPostRepository,
+                userRepository,
+                elasticSearchInstance,
+                fileStorageExecutor,
+                sheetPostViewCountRepository,
+                authenticationUtil,
+                fileUploadService,
+                eventPublisher,
+                sheetPostOutboxService,
+                sheetPostCacheCoordinator);
+        ReflectionTestUtils.setField(service, "likeCountRepository", likeCountRepository);
+    }
+
+    @Test
+    @DisplayName("SheetPost 수정은 직접 ES를 건드리지 않고 outbox 업데이트 이벤트를 적재한다")
+    void updateEnqueuesOutboxInsteadOfDirectElasticMutation() throws IOException {
+        Long sheetPostId = 10L;
+        User loggedInUser = mock(User.class);
+        SheetPost sheetPost = mock(SheetPost.class);
+        UpdateSheetPostDto dto = mock(UpdateSheetPostDto.class);
+
+        when(authenticationUtil.getLoggedInUser()).thenReturn(loggedInUser);
+        when(sheetPostRepository.findById(sheetPostId)).thenReturn(Optional.of(sheetPost));
+        when(sheetPost.getAuthor()).thenReturn(loggedInUser);
+        when(sheetPost.getId()).thenReturn(sheetPostId);
+        when(dto.getUploadId()).thenReturn(null);
+        when(sheetPost.update(dto)).thenReturn(sheetPost);
+
+        service.update(sheetPostId, dto);
+
+        verify(sheetPostOutboxService).enqueueUpdated(sheetPostId);
+        verify(elasticSearchInstance, never()).invertIndexingSheetPost(sheetPost);
+        verify(sheetPostCacheCoordinator).evictSheetPostListCache();
+        verify(sheetPostCacheCoordinator).evictSheetPostDetailCache(sheetPostId);
+    }
+
+    @Test
+    @DisplayName("SheetPost 삭제는 권한 확인 후 DB 삭제와 outbox 삭제 이벤트 적재를 수행한다")
+    void deleteChecksAuthorizationBeforeDeleteAndEnqueuesOutbox() {
+        Long sheetPostId = 20L;
+        User loggedInUser = mock(User.class);
+        SheetPost sheetPost = mock(SheetPost.class);
+
+        when(authenticationUtil.getLoggedInUser()).thenReturn(loggedInUser);
+        when(sheetPostRepository.findById(sheetPostId)).thenReturn(Optional.of(sheetPost));
+        when(sheetPost.getAuthor()).thenReturn(loggedInUser);
+        when(sheetPost.getId()).thenReturn(sheetPostId);
+
+        service.delete(sheetPostId);
+
+        verify(fileStorageExecutor).removeSheetPost(sheetPost);
+        verify(sheetPostRepository).deleteById(sheetPostId);
+        verify(sheetPostOutboxService).enqueueDeleted(sheetPostId);
+        verify(elasticSearchInstance, never()).deleteSheetPostIndex(sheetPostId);
+    }
+
+    @Test
+    @DisplayName("권한 없는 삭제 요청은 파일 삭제와 outbox 적재를 수행하지 않는다")
+    void deleteRejectsUnauthorizedRequestBeforeSideEffects() {
+        Long sheetPostId = 30L;
+        User loggedInUser = mock(User.class);
+        User author = mock(User.class);
+        SheetPost sheetPost = mock(SheetPost.class);
+
+        when(authenticationUtil.getLoggedInUser()).thenReturn(loggedInUser);
+        when(sheetPostRepository.findById(sheetPostId)).thenReturn(Optional.of(sheetPost));
+        when(sheetPost.getAuthor()).thenReturn(author);
+
+        org.junit.jupiter.api.Assertions.assertThrows(AccessDeniedException.class, () -> service.delete(sheetPostId));
+
+        verify(fileStorageExecutor, never()).removeSheetPost(sheetPost);
+        verify(sheetPostRepository, never()).deleteById(sheetPostId);
+        verify(sheetPostOutboxService, never()).enqueueDeleted(sheetPostId);
+    }
+}

--- a/src/test/java/com/omegafrog/My/piano/app/web/service/outbox/SheetPostOutboxProcessorTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/web/service/outbox/SheetPostOutboxProcessorTest.java
@@ -72,9 +72,38 @@ class SheetPostOutboxProcessorTest {
     }
 
     @Test
+    @DisplayName("수정 이벤트도 Elasticsearch upsert 성공 후 완료 처리한다")
+    void completeUpdatedEventAfterSuccessfulIndexing() {
+        SheetPostOutboxEvent event = SheetPostOutboxEvent.pending("evt-2", 11L, SheetPostOutboxEventType.SHEET_POST_UPDATED);
+        SheetPost sheetPost = org.mockito.Mockito.mock(SheetPost.class);
+
+        when(outboxRepository.findProcessable(any(LocalDateTime.class), anyInt())).thenReturn(List.of(event));
+        when(sheetPostRepository.findById(11L)).thenReturn(Optional.of(sheetPost));
+
+        processor.processPendingEvents();
+
+        assertThat(event.getStatus()).isEqualTo(SheetPostOutboxEventStatus.COMPLETED);
+        verify(elasticSearchInstance).saveSheetPostIndex(sheetPost);
+    }
+
+    @Test
+    @DisplayName("삭제 이벤트는 엔티티 재조회 없이 Elasticsearch delete 성공 후 완료 처리한다")
+    void completeDeletedEventAfterSuccessfulDelete() {
+        SheetPostOutboxEvent event = SheetPostOutboxEvent.pending("evt-3", 12L, SheetPostOutboxEventType.SHEET_POST_DELETED);
+
+        when(outboxRepository.findProcessable(any(LocalDateTime.class), anyInt())).thenReturn(List.of(event));
+
+        processor.processPendingEvents();
+
+        assertThat(event.getStatus()).isEqualTo(SheetPostOutboxEventStatus.COMPLETED);
+        verify(elasticSearchInstance).deleteSheetPostIndex(12L);
+        verify(sheetPostRepository, never()).findById(any());
+    }
+
+    @Test
     @DisplayName("Elasticsearch 저장 실패 시 completed 처리하지 않고 재시도 가능 상태로 남긴다")
     void markFailedWhenIndexingThrows() {
-        SheetPostOutboxEvent event = SheetPostOutboxEvent.pending("evt-2", 20L, SheetPostOutboxEventType.SHEET_POST_CREATED);
+        SheetPostOutboxEvent event = SheetPostOutboxEvent.pending("evt-4", 20L, SheetPostOutboxEventType.SHEET_POST_CREATED);
         SheetPost sheetPost = org.mockito.Mockito.mock(SheetPost.class);
 
         when(outboxRepository.findProcessable(any(LocalDateTime.class), anyInt())).thenReturn(List.of(event));


### PR DESCRIPTION
## 변경 배경
- 관련 이슈: Closes #93
- 선행 PR: #99
- 생성은 outbox를 사용하지만 수정은 직접 async indexing, 삭제는 직접 Elasticsearch delete를 호출하고 있었습니다.
- 특히 삭제 경로는 권한 확인 전에 파일/검색 인덱스 side effect가 먼저 실행될 수 있어, 권한 없는 요청이 검색 문서를 먼저 숨기는 문제가 생길 수 있었습니다.

## 주요 변경사항
- `SheetPostOutboxEventType`에 `SHEET_POST_UPDATED`, `SHEET_POST_DELETED`를 추가했습니다.
- `SheetPostOutboxService`에 `enqueueUpdated(...)`, `enqueueDeleted(...)`를 추가하고 공통 enqueue 흐름으로 정리했습니다.
- `SheetPostApplicationService.update(...)`는 직접 Elasticsearch 호출 대신 update outbox event를 적재합니다.
- `SheetPostApplicationService.delete(...)`는 권한 확인을 side effect보다 먼저 수행하고, DB 삭제 후 delete outbox event를 적재합니다.
- `SheetPostOutboxProcessor`는 created/updated는 upsert, deleted는 delete로 Elasticsearch projection을 반영합니다.
- `SheetPostApplicationService`에서 직접 `SheetPostIndexRepository` 의존성을 제거했습니다.

## Implementation intent
SheetPost 생성/수정/삭제의 검색 projection 갱신 경로를 outbox 기반으로 통일해 DB 변경과 Elasticsearch read model 사이의 정합성 회복 가능성을 확보합니다.

## Implementation approach
- Write path에서 Elasticsearch를 직접 건드리지 않고 outbox event만 저장합니다.
- Outbox processor가 event type을 기준으로 Elasticsearch upsert/delete를 수행합니다.
- 삭제는 권한 확인을 먼저 통과한 뒤 파일 삭제, DB 삭제, outbox delete enqueue 순서로 진행합니다.
- 선행 PR #99의 동기 `saveSheetPostIndex(...)` 경로를 사용하므로, processor는 ES 작업 성공 후에만 completed 처리합니다.

## Verification method
- `python3 -m graphify update .`
  - 성공: `graphify-out/` 산출물을 워크트리에서 사용 가능하도록 갱신
- `python3 -m graphify path "SheetPostApplicationService" "SheetPostOutboxService" --graph graphify-out/graph.json`
  - 성공: write path와 outbox service 관계 확인
- `bash ./gradlew test --tests com.omegafrog.My.piano.app.web.service.outbox.SheetPostOutboxProcessorTest --tests com.omegafrog.My.piano.app.web.service.SheetPostApplicationServiceOutboxTest`
  - 성공: focused regression tests 통과
- `bash ./gradlew build`
  - 실패: 기존 캐시/Ehcache 계열 테스트 5개 실패
  - 실패 테스트
    - `EhcacheSmokeTest`
    - `EhcacheTtlContractTest`
    - `JCacheCacheManagerOverrideIntegrationTest` 2개
    - `SheetPostCacheWarmupJobIntegrationTest`

## 테스트/검증 결과
- 수정 요청은 직접 ES 호출 없이 update outbox event를 적재하는지 검증했습니다.
- 삭제 요청은 권한 확인 후 DB delete와 delete outbox event를 적재하는지 검증했습니다.
- 권한 없는 삭제 요청은 파일 삭제, DB delete, outbox 적재를 수행하지 않는지 검증했습니다.
- Processor는 update event를 upsert하고 delete event를 entity 재조회 없이 ES delete하는지 검증했습니다.

## 영향 범위 및 리스크
- 영향 범위는 SheetPost 수정/삭제 write path와 SheetPost outbox processor입니다.
- 이 PR은 #99가 먼저 머지되어야 합니다.
- 남은 리스크:
  - outbox event ordering/versioning은 아직 SheetPost 쪽에 없습니다. 빠른 연속 update/delete 순서 보장은 별도 후속 개선이 필요합니다.
  - 실제 alias/read-write index 정리는 #91에서 처리해야 합니다.
