### PR TITLE
[codex] 검색 결과 순서 보존

### DIFF
--- a/src/main/java/com/omegafrog/My/piano/app/web/infra/sheetPost/JpaSheetPostRepositoryImpl.java
+++ b/src/main/java/com/omegafrog/My/piano/app/web/infra/sheetPost/JpaSheetPostRepositoryImpl.java
@@ -1,6 +1,9 @@
 package com.omegafrog.My.piano.app.web.infra.sheetPost;
 
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Locale;
 
@@ -177,6 +180,11 @@ public class JpaSheetPostRepositoryImpl implements SheetPostRepository {
 
 	@Override
 	public List<SheetPostListDto> findByIds(List<Long> sheetPostIds, Pageable pageable) {
+		Map<Long, Integer> searchRankById = new HashMap<>();
+		for (int i = 0; i < sheetPostIds.size(); i++) {
+			searchRankById.putIfAbsent(sheetPostIds.get(i), i);
+		}
+
 		QSheetPost sheetPost = QSheetPost.sheetPost;
 		QUser user = QUser.user;
 		QSheet sheet = QSheet.sheet;
@@ -198,12 +206,14 @@ public class JpaSheetPostRepositoryImpl implements SheetPostRepository {
 					sheetPost.price
 				))
 			.from(sheetPost)
-			.join(sheetPost.author, user)
-			.join(sheetPost.sheet, sheet)
-			.where(expressions)
-			.orderBy(sheetPost.createdAt.desc());
+				.join(sheetPost.author, user)
+				.join(sheetPost.sheet, sheet)
+				.where(expressions);
 
-		return query.fetch();
+			return query.fetch().stream()
+					.sorted(Comparator.comparingInt(row ->
+							searchRankById.getOrDefault(row.getId(), Integer.MAX_VALUE)))
+					.toList();
 	}
 
 	@Override

--- a/src/test/java/com/omegafrog/My/piano/app/web/infrastructure/sheet/SheetPostRepositoryTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/web/infrastructure/sheet/SheetPostRepositoryTest.java
@@ -6,6 +6,7 @@ import com.omegafrog.My.piano.app.web.domain.cart.Cart;
 import com.omegafrog.My.piano.app.web.domain.sheet.Genres;
 import com.omegafrog.My.piano.app.web.domain.user.UserRepository;
 import com.omegafrog.My.piano.app.web.dto.sheetPost.UpdateSheetDto;
+import com.omegafrog.My.piano.app.web.dto.sheetPost.SheetPostListDto;
 import com.omegafrog.My.piano.app.web.enums.Difficulty;
 import com.omegafrog.My.piano.app.web.enums.Genre;
 import com.omegafrog.My.piano.app.web.enums.Instrument;
@@ -23,8 +24,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @DataJpaTest
@@ -101,6 +104,22 @@ class SheetPostRepositoryTest {
         sheetPostRepository.deleteById(saved.getId());
         Optional<SheetPost> founded = sheetPostRepository.findById(saved.getId());
         Assertions.assertThat(founded).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Elasticsearch 검색 순서대로 악보 판매글을 조회할 수 있어야 한다.")
+    void findByIdsKeepsSearchResultOrder() {
+        SheetPost first = sheetPostRepository.save(DummyData.sheetPost(a));
+        SheetPost second = sheetPostRepository.save(DummyData.sheetPost(a));
+        SheetPost third = sheetPostRepository.save(DummyData.sheetPost(a));
+
+        List<Long> searchOrderedIds = List.of(third.getId(), first.getId(), second.getId());
+
+        List<Long> actualIds = sheetPostRepository.findByIds(searchOrderedIds, PageRequest.of(0, 3)).stream()
+                .map(SheetPostListDto::getId)
+                .toList();
+
+        Assertions.assertThat(actualIds).containsExactlyElementsOf(searchOrderedIds);
     }
 
 }


### PR DESCRIPTION
## 변경 배경
Elasticsearch가 relevance 순서로 반환한 sheet post id 목록이 DB 재조회 과정에서 `createdAt.desc()`로 다시 정렬되어 최종 응답 순서가 검색 점수와 달라지는 문제를 해결합니다.

## Implementation intent
Issue #94의 목적대로 ES 검색 결과 id 순서를 최종 API 응답 DTO 순서까지 보존합니다.

## Implementation approach
`SheetPostRepository.findByIds(...)`에서 입력 id 목록의 rank map을 만든 뒤, QueryDSL로 조회한 `SheetPostListDto` 목록을 해당 rank 기준으로 정렬합니다. DB 조회는 id 조건으로 필요한 row만 가져오고, pagination total/count는 기존처럼 ES 결과의 total 값을 사용하므로 기존 pagination metadata 흐름은 유지됩니다.

## 주요 변경사항
- `JpaSheetPostRepositoryImpl.findByIds`: `createdAt.desc()` 정렬 제거, 입력 id 순서 기반 DTO 정렬 추가
- `SheetPostRepositoryTest`: ES id 순서가 `findByIds` 결과에 그대로 반영되는 regression test 추가

## Verification method
- 성공: `JAVA_HOME=/home/jiwoo/.sdkman/candidates/java/current PATH=/home/jiwoo/.sdkman/candidates/java/current/bin:$PATH bash ./gradlew compileJava testClasses -x ensureTestInfra`
- 실패(환경): `JAVA_HOME=/home/jiwoo/.sdkman/candidates/java/current PATH=/home/jiwoo/.sdkman/candidates/java/current/bin:$PATH bash ./gradlew test --tests com.omegafrog.My.piano.app.web.infrastructure.sheet.SheetPostRepositoryTest -x ensureTestInfra` 실행 시 MySQL 연결 실패(`java.net.ConnectException`)
- 실패(환경): `bash ./gradlew test --tests com.omegafrog.My.piano.app.web.infrastructure.sheet.SheetPostRepositoryTest` 실행 시 WSL에서 `docker-compose` 미설치로 `ensureTestInfra` 실패

## 테스트/검증 결과
컴파일과 testClasses 생성은 성공했습니다. 실제 JPA 테스트 실행은 로컬 MySQL/도커 컴포즈 환경 부재로 완료하지 못했습니다.

## 영향 범위 및 리스크
검색 id hydration 경로만 변경합니다. ES에서 반환된 id 중 DB에 없는 row는 기존처럼 누락되고, 존재하는 row의 상대 순서만 ES rank와 일치하도록 보정됩니다.

Closes #94