### PR TITLE
[codex] 회원가입 username 중복 방지

### DIFF
--- a/src/main/java/com/omegafrog/My/piano/app/web/domain/user/SecurityUser.java
+++ b/src/main/java/com/omegafrog/My/piano/app/web/domain/user/SecurityUser.java
@@ -23,7 +23,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,6 +33,9 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity(name = "security_user")
+@Table(name = "security_user", uniqueConstraints = {
+		@UniqueConstraint(name = "uk_security_user_username", columnNames = "username")
+})
 @NoArgsConstructor
 @Getter
 @Setter(AccessLevel.PRIVATE)
@@ -44,7 +49,7 @@ public class SecurityUser implements UserDetails {
 	@Getter
 	private Long id;
 
-	@Column(unique = true)
+	@Column(nullable = false)
 	private String username;
 	private String password;
 	private Role role;

--- a/src/main/java/com/omegafrog/My/piano/app/web/service/admin/CommonUserService.java
+++ b/src/main/java/com/omegafrog/My/piano/app/web/service/admin/CommonUserService.java
@@ -139,8 +139,18 @@ public class CommonUserService implements UserDetailsService {
             SecurityUser saved = securityUserRepository.save(securityUser);
             return saved.toDto();
         } catch (DataIntegrityViolationException ex) {
-            throw new DuplicatePropertyException("중복된 ID가 존재합니다.", ex);
+            throw resolveDuplicateRegistrationException(dto, ex);
         }
+    }
+
+    private DuplicatePropertyException resolveDuplicateRegistrationException(RegisterUserDto dto, DataIntegrityViolationException ex) {
+        if (securityUserRepository.findByUsername(dto.getUsername()).isPresent()) {
+            return new DuplicatePropertyException("중복된 ID가 존재합니다.", ex);
+        }
+        if (securityUserRepository.findByEmail(dto.getEmail()).isPresent()) {
+            return new DuplicatePropertyException("중복된 이메일이 존재합니다.", ex);
+        }
+        return new DuplicatePropertyException("중복된 ID가 존재합니다.", ex);
     }
 
     public SecurityUserDto registerUser(RegisterUserDto dto, MultipartFile profileImg) throws DuplicatePropertyException, IOException {

--- a/src/main/java/com/omegafrog/My/piano/app/web/service/admin/CommonUserService.java
+++ b/src/main/java/com/omegafrog/My/piano/app/web/service/admin/CommonUserService.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -42,10 +43,14 @@ import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 @RequiredArgsConstructor
 @Slf4j
 public class CommonUserService implements UserDetailsService {
+
+    private static final Set<String> USERNAMES_IN_REGISTRATION = ConcurrentHashMap.newKeySet();
 
     @Lazy
     private final PasswordEncoder passwordEncoder;
@@ -101,6 +106,18 @@ public class CommonUserService implements UserDetailsService {
     }
 
     public SecurityUserDto registerUserWithoutProfile(RegisterUserDto dto) throws DuplicatePropertyException {
+        String username = dto.getUsername();
+        if (!USERNAMES_IN_REGISTRATION.add(username)) {
+            throw new DuplicatePropertyException("중복된 ID가 존재합니다.");
+        }
+        try {
+            return registerUniqueUser(dto);
+        } finally {
+            USERNAMES_IN_REGISTRATION.remove(username);
+        }
+    }
+
+    private SecurityUserDto registerUniqueUser(RegisterUserDto dto) throws DuplicatePropertyException {
         User user = dto.toEntity();
         SecurityUser.SecurityUserBuilder builder = SecurityUser.builder()
                 .username(dto.getUsername())
@@ -118,8 +135,12 @@ public class CommonUserService implements UserDetailsService {
         if (byEmail.isPresent())
             throw new DuplicatePropertyException("중복된 이메일이 존재합니다.");
 
-        SecurityUser saved = securityUserRepository.save(securityUser);
-        return saved.toDto();
+        try {
+            SecurityUser saved = securityUserRepository.save(securityUser);
+            return saved.toDto();
+        } catch (DataIntegrityViolationException ex) {
+            throw new DuplicatePropertyException("중복된 ID가 존재합니다.", ex);
+        }
     }
 
     public SecurityUserDto registerUser(RegisterUserDto dto, MultipartFile profileImg) throws DuplicatePropertyException, IOException {

--- a/src/test/java/com/omegafrog/My/piano/app/security/service/CommonUserRegistrationTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/security/service/CommonUserRegistrationTest.java
@@ -1,0 +1,101 @@
+package com.omegafrog.My.piano.app.security.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.omegafrog.My.piano.app.security.exception.DuplicatePropertyException;
+import com.omegafrog.My.piano.app.web.domain.user.SecurityUser;
+import com.omegafrog.My.piano.app.web.domain.user.SecurityUserRepository;
+import com.omegafrog.My.piano.app.web.dto.user.RegisterUserDto;
+import com.omegafrog.My.piano.app.web.service.admin.CommonUserService;
+import com.omegafrog.My.piano.app.web.vo.user.LoginMethod;
+
+@ExtendWith(MockitoExtension.class)
+class CommonUserRegistrationTest {
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private SecurityUserRepository securityUserRepository;
+
+    private CommonUserService commonUserService;
+
+    @BeforeEach
+    void setUp() {
+        commonUserService = new CommonUserService(passwordEncoder, securityUserRepository, null, null, null, null);
+        when(passwordEncoder.encode("password")).thenReturn("encoded-password");
+    }
+
+    @Test
+    @DisplayName("동일 username 회원가입이 동시에 들어오면 하나만 저장 시도해야 한다.")
+    void concurrentRegisterWithSameUsernameAttemptsSingleSave() throws Exception {
+        CountDownLatch firstSaveStarted = new CountDownLatch(1);
+        CountDownLatch releaseFirstSave = new CountDownLatch(1);
+        when(securityUserRepository.findByUsername("user1")).thenReturn(Optional.empty());
+        when(securityUserRepository.findByEmail("user1@email.com")).thenReturn(Optional.empty());
+        when(securityUserRepository.save(any(SecurityUser.class))).thenAnswer(invocation -> {
+            firstSaveStarted.countDown();
+            releaseFirstSave.await(2, TimeUnit.SECONDS);
+            return invocation.getArgument(0);
+        });
+
+        FutureTask<Void> firstRegister = new FutureTask<>(() -> {
+            commonUserService.registerUserWithoutProfile(registerDto("user1", "user1@email.com"));
+            return null;
+        });
+        Thread firstThread = new Thread(firstRegister);
+        firstThread.start();
+        assertThat(firstSaveStarted.await(2, TimeUnit.SECONDS)).isTrue();
+
+        assertThatThrownBy(() -> commonUserService.registerUserWithoutProfile(registerDto("user1", "user1@email.com")))
+                .isInstanceOf(DuplicatePropertyException.class)
+                .hasMessage("중복된 ID가 존재합니다.");
+
+        releaseFirstSave.countDown();
+        firstRegister.get(2, TimeUnit.SECONDS);
+        verify(securityUserRepository, times(1)).save(any(SecurityUser.class));
+    }
+
+    @Test
+    @DisplayName("DB unique 제약 위반은 중복 ID 예외로 변환해야 한다.")
+    void dataIntegrityViolationIsConvertedToDuplicateUsernameException() {
+        when(securityUserRepository.findByUsername("user1")).thenReturn(Optional.empty());
+        when(securityUserRepository.findByEmail("user1@email.com")).thenReturn(Optional.empty());
+        when(securityUserRepository.save(any(SecurityUser.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate username"));
+
+        assertThatThrownBy(() -> commonUserService.registerUserWithoutProfile(registerDto("user1", "user1@email.com")))
+                .isInstanceOf(DuplicatePropertyException.class)
+                .hasMessage("중복된 ID가 존재합니다.");
+    }
+
+    private RegisterUserDto registerDto(String username, String email) {
+        return RegisterUserDto.builder()
+                .username(username)
+                .password("password")
+                .name("user")
+                .email(email)
+                .loginMethod(LoginMethod.EMAIL)
+                .profileSrc("profileSrc")
+                .phoneNum("010-1111-2222")
+                .build();
+    }
+}

--- a/src/test/java/com/omegafrog/My/piano/app/security/service/CommonUserRegistrationTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/security/service/CommonUserRegistrationTest.java
@@ -77,7 +77,12 @@ class CommonUserRegistrationTest {
     @Test
     @DisplayName("DB unique 제약 위반은 중복 ID 예외로 변환해야 한다.")
     void dataIntegrityViolationIsConvertedToDuplicateUsernameException() {
-        when(securityUserRepository.findByUsername("user1")).thenReturn(Optional.empty());
+        SecurityUser existingUser = SecurityUser.builder()
+                .username("user1")
+                .password("encoded-password")
+                .role(com.omegafrog.My.piano.app.web.domain.user.authorities.Role.USER)
+                .build();
+        when(securityUserRepository.findByUsername("user1")).thenReturn(Optional.empty(), Optional.of(existingUser));
         when(securityUserRepository.findByEmail("user1@email.com")).thenReturn(Optional.empty());
         when(securityUserRepository.save(any(SecurityUser.class)))
                 .thenThrow(new DataIntegrityViolationException("duplicate username"));
@@ -85,6 +90,24 @@ class CommonUserRegistrationTest {
         assertThatThrownBy(() -> commonUserService.registerUserWithoutProfile(registerDto("user1", "user1@email.com")))
                 .isInstanceOf(DuplicatePropertyException.class)
                 .hasMessage("중복된 ID가 존재합니다.");
+    }
+
+    @Test
+    @DisplayName("DB email unique 제약 위반은 중복 이메일 예외로 변환해야 한다.")
+    void dataIntegrityViolationIsConvertedToDuplicateEmailException() {
+        SecurityUser existingUser = SecurityUser.builder()
+                .username("other")
+                .password("encoded-password")
+                .role(com.omegafrog.My.piano.app.web.domain.user.authorities.Role.USER)
+                .build();
+        when(securityUserRepository.findByUsername("user1")).thenReturn(Optional.empty(), Optional.empty());
+        when(securityUserRepository.findByEmail("user1@email.com")).thenReturn(Optional.empty(), Optional.of(existingUser));
+        when(securityUserRepository.save(any(SecurityUser.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate email"));
+
+        assertThatThrownBy(() -> commonUserService.registerUserWithoutProfile(registerDto("user1", "user1@email.com")))
+                .isInstanceOf(DuplicatePropertyException.class)
+                .hasMessage("중복된 이메일이 존재합니다.");
     }
 
     private RegisterUserDto registerDto(String username, String email) {


### PR DESCRIPTION
## 변경 배경
Issue #61: register를 연속 클릭하면 동일 username 유저가 여러 개 생성될 수 있는 문제를 막습니다. 기존 사전 조회만으로는 동시 요청이 같은 username으로 동시에 통과할 수 있습니다.

## Implementation intent
회원가입 시 username 중복을 서비스 레벨과 DB 제약 레벨에서 모두 방지해 동일 username 계정이 중복 생성되지 않게 합니다.

## Implementation approach
`CommonUserService.registerUserWithoutProfile(...)` 진입 시 username별 in-flight guard를 사용해 같은 JVM 안에서 동시에 들어온 같은 username 요청 중 하나만 저장 경로로 진행시킵니다. 저장 직전 기존 username/email 중복 조회는 유지하고, DB unique 제약 위반은 `DuplicatePropertyException`으로 변환해 기존 400 응답 흐름을 유지합니다. `SecurityUser`에는 명시적 named unique constraint를 추가해 schema 생성 시 username unique 조건이 더 분명하게 드러나도록 했습니다.

## 주요 변경사항
- `SecurityUser`: `uk_security_user_username` named unique constraint 추가, username nullable=false 적용
- `CommonUserService`: username별 동시 회원가입 guard 추가, `DataIntegrityViolationException` -> `DuplicatePropertyException` 변환 추가
- `CommonUserRegistrationTest`: 동시 동일 username 요청 저장 1회 보장, DB unique 위반 예외 변환 검증

## Verification method
- 성공: `JAVA_HOME=/home/jiwoo/.sdkman/candidates/java/current PATH=/home/jiwoo/.sdkman/candidates/java/current/bin:$PATH bash ./gradlew test --tests com.omegafrog.My.piano.app.security.service.CommonUserRegistrationTest -x ensureTestInfra`
- 실패(환경): `JAVA_HOME=/home/jiwoo/.sdkman/candidates/java/current PATH=/home/jiwoo/.sdkman/candidates/java/current/bin:$PATH bash ./gradlew build` 실행 시 `ensureTestInfra`에서 WSL `docker-compose` 미설치로 실패

## 테스트/검증 결과
신규 단위 테스트는 성공했습니다. 전체 build는 assemble/compile 이후 테스트 인프라 자동 기동 단계에서 환경 문제로 중단되었습니다.

## 영향 범위 및 리스크
영향 범위는 일반 유저 회원가입 경로입니다. 단일 애플리케이션 인스턴스 안의 연속 클릭/동시 요청은 in-flight guard로 차단하고, 다중 인스턴스나 DB 레벨 race는 unique constraint와 예외 변환으로 방어합니다.

Closes #61