### PR TITLE
[codex] 인증 details 사용자 정보 설정

### DIFF
--- a/src/main/java/com/omegafrog/My/piano/app/security/filter/CommonUserJwtTokenFilter.java
+++ b/src/main/java/com/omegafrog/My/piano/app/security/filter/CommonUserJwtTokenFilter.java
@@ -2,6 +2,7 @@ package com.omegafrog.My.piano.app.security.filter;
 
 import com.omegafrog.My.piano.app.security.jwt.RefreshTokenRepository;
 import com.omegafrog.My.piano.app.security.jwt.TokenUtils;
+import com.omegafrog.My.piano.app.web.domain.user.SecurityUser;
 import com.omegafrog.My.piano.app.web.domain.user.SecurityUserRepository;
 import com.omegafrog.My.piano.app.web.domain.user.authorities.Role;
 import io.jsonwebtoken.Claims;
@@ -20,7 +21,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -85,7 +85,7 @@ public class CommonUserJwtTokenFilter extends OncePerRequestFilter {
                 throw new BadCredentialsException("Already logged out user.");
             }
             // token validation 진행
-            UserDetails user = getUserFromAccessToken(userId);
+            SecurityUser user = getUserFromAccessToken(userId);
             Authentication usernameToken = getAuthenticationToken(user);
             SecurityContextHolder.getContext().setAuthentication(usernameToken);
         } catch (ExpiredJwtException e) {
@@ -96,13 +96,15 @@ public class CommonUserJwtTokenFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private UserDetails getUserFromAccessToken(Long userId) {
+    private SecurityUser getUserFromAccessToken(Long userId) {
         return securityUserRepository.findById(userId).orElseThrow(
                 () -> new EntityNotFoundException("Cannot find User entity"));
     }
 
-    private static Authentication getAuthenticationToken(UserDetails user) {
-        return new UsernamePasswordAuthenticationToken(
+    private static Authentication getAuthenticationToken(SecurityUser user) {
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                 user, null, user.getAuthorities());
+        authentication.setDetails(user.getUser());
+        return authentication;
     }
 }

--- a/src/main/java/com/omegafrog/My/piano/app/security/provider/CommonUserAuthenticationProvider.java
+++ b/src/main/java/com/omegafrog/My/piano/app/security/provider/CommonUserAuthenticationProvider.java
@@ -24,8 +24,10 @@ public class CommonUserAuthenticationProvider implements AuthenticationProvider 
 
         if (foundedUserDetails.isEnabled()) {
             if (passwordEncoder.matches((CharSequence) authentication.getCredentials(), foundedUserDetails.getPassword())) {
-                return new UsernamePasswordAuthenticationToken(foundedUserDetails,
+                UsernamePasswordAuthenticationToken authenticated = new UsernamePasswordAuthenticationToken(foundedUserDetails,
                         foundedUserDetails.getPassword(), foundedUserDetails.getAuthorities());
+                authenticated.setDetails(foundedUserDetails.getUser());
+                return authenticated;
             } else {
                 throw new BadCredentialsException("Password is not match.");
             }

--- a/src/main/java/com/omegafrog/My/piano/app/security/provider/JwtAuthenticationProvider.java
+++ b/src/main/java/com/omegafrog/My/piano/app/security/provider/JwtAuthenticationProvider.java
@@ -43,7 +43,9 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
             SecurityUser user = findUser(securityUserId);
             RefreshToken refreshToken = findRefreshToken(securityUserId, securityUserRole);
             TokenInfo tokenInfo = tokenUtils.wrap(accessToken, refreshToken);
-            return JwtAuthenticationToken.authenticated(user.getAuthorities(), tokenInfo, securityUserId);
+            JwtAuthenticationToken authenticated = JwtAuthenticationToken.authenticated(user.getAuthorities(), tokenInfo, securityUserId);
+            authenticated.setDetails(user.getUser());
+            return authenticated;
         } catch (ExpiredJwtException e) {
             validateExpiredTokenClaims(e);
             throw new CredentialsExpiredException("Access token is expired.", e);

--- a/src/main/java/com/omegafrog/My/piano/app/utils/AuthenticationUtil.java
+++ b/src/main/java/com/omegafrog/My/piano/app/utils/AuthenticationUtil.java
@@ -24,6 +24,11 @@ public class AuthenticationUtil {
             throw new AccessDeniedException("authentication is null");
         }
 
+        Object details = authentication.getDetails();
+        if (details instanceof User user) {
+            return user;
+        }
+
         Object principal = authentication.getPrincipal();
         if (!(principal instanceof SecurityUser securityUser)) {
             throw new AccessDeniedException("unexpected principal type");

--- a/src/main/java/com/omegafrog/My/piano/app/web/controller/SecurityController.java
+++ b/src/main/java/com/omegafrog/My/piano/app/web/controller/SecurityController.java
@@ -138,6 +138,7 @@ public class SecurityController {
         securityUser,
         null,
         securityUser.getAuthorities());
+    authentication.setDetails(securityUser.getUser());
     SecurityContext context = SecurityContextHolder.createEmptyContext();
     context.setAuthentication(authentication);
     SecurityContextHolder.setContext(context);

--- a/src/test/java/com/omegafrog/My/piano/app/security/provider/CommonUserAuthenticationProviderTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/security/provider/CommonUserAuthenticationProviderTest.java
@@ -1,0 +1,61 @@
+package com.omegafrog.My.piano.app.security.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.omegafrog.My.piano.app.web.domain.cart.Cart;
+import com.omegafrog.My.piano.app.web.domain.user.SecurityUser;
+import com.omegafrog.My.piano.app.web.domain.user.User;
+import com.omegafrog.My.piano.app.web.domain.user.authorities.Role;
+import com.omegafrog.My.piano.app.web.service.admin.CommonUserService;
+import com.omegafrog.My.piano.app.web.vo.user.LoginMethod;
+
+@ExtendWith(MockitoExtension.class)
+class CommonUserAuthenticationProviderTest {
+
+    @Mock
+    private CommonUserService commonUserService;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("로그인 인증 성공 시 Authentication details에는 User를 담아야 한다.")
+    void authenticatedTokenDetailsContainsUser() {
+        User user = user();
+        SecurityUser securityUser = SecurityUser.builder()
+                .username("user1")
+                .password("encoded-password")
+                .role(Role.USER)
+                .user(user)
+                .build();
+        CommonUserAuthenticationProvider provider = new CommonUserAuthenticationProvider(commonUserService, passwordEncoder);
+
+        given(commonUserService.loadUserByUsername("user1")).willReturn(securityUser);
+        given(passwordEncoder.matches("password", "encoded-password")).willReturn(true);
+
+        Authentication authentication = provider.authenticate(
+                UsernamePasswordAuthenticationToken.unauthenticated("user1", "password"));
+
+        assertThat(authentication.getPrincipal()).isSameAs(securityUser);
+        assertThat(authentication.getDetails()).isSameAs(user);
+    }
+
+    private User user() {
+        return User.builder()
+                .name("user")
+                .email("user@email.com")
+                .loginMethod(LoginMethod.EMAIL)
+                .cart(new Cart())
+                .profileSrc("profileSrc")
+                .build();
+    }
+}

--- a/src/test/java/com/omegafrog/My/piano/app/security/provider/JwtAuthenticationProviderTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/security/provider/JwtAuthenticationProviderTest.java
@@ -4,9 +4,12 @@ import com.omegafrog.My.piano.app.security.jwt.JwtAuthenticationToken;
 import com.omegafrog.My.piano.app.security.jwt.RefreshToken;
 import com.omegafrog.My.piano.app.security.jwt.RefreshTokenRepository;
 import com.omegafrog.My.piano.app.security.jwt.TokenUtils;
+import com.omegafrog.My.piano.app.web.domain.cart.Cart;
 import com.omegafrog.My.piano.app.web.domain.user.SecurityUser;
 import com.omegafrog.My.piano.app.web.domain.user.SecurityUserRepository;
+import com.omegafrog.My.piano.app.web.domain.user.User;
 import com.omegafrog.My.piano.app.web.domain.user.authorities.Role;
+import com.omegafrog.My.piano.app.web.vo.user.LoginMethod;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -47,10 +50,12 @@ class JwtAuthenticationProviderTest {
     @DisplayName("유효한 access token이면 authenticated JWT Authentication을 반환한다")
     void authenticateWithValidToken() {
         Claims claims = claims("1", Role.USER);
+        User user = user();
         SecurityUser securityUser = SecurityUser.builder()
                 .username("user1")
                 .password("encoded")
                 .role(Role.USER)
+                .user(user)
                 .build();
         RefreshToken refreshToken = RefreshToken.builder()
                 .id("USER-1")
@@ -71,6 +76,7 @@ class JwtAuthenticationProviderTest {
         assertThat(authentication).isInstanceOf(JwtAuthenticationToken.class);
         assertThat(authentication.isAuthenticated()).isTrue();
         assertThat(authentication.getPrincipal()).isEqualTo(1L);
+        assertThat(authentication.getDetails()).isSameAs(user);
     }
 
     @Test
@@ -136,5 +142,15 @@ class JwtAuthenticationProviderTest {
         claims.put("id", id);
         claims.put("role", role.value);
         return claims;
+    }
+
+    private User user() {
+        return User.builder()
+                .name("user")
+                .email("user@email.com")
+                .loginMethod(LoginMethod.EMAIL)
+                .cart(new Cart())
+                .profileSrc("profileSrc")
+                .build();
     }
 }


### PR DESCRIPTION
## 변경 배경
Issue #48: Authentication details에 `SecurityUser`가 아니라 domain `User`가 들어가야 하는 문제를 수정합니다. 서비스 계층은 실제 도메인 사용자 정보가 필요하므로 인증 생성 시 details 값을 일관되게 `User`로 설정합니다.

## Implementation intent
폼 로그인, JWT 인증, OAuth 세션 인증에서 `Authentication.getDetails()`가 domain `User`를 반환하도록 보장합니다.

## Implementation approach
`CommonUserAuthenticationProvider`, `CommonUserJwtTokenFilter`, `JwtAuthenticationProvider`, OAuth 세션 생성 경로에서 인증 토큰을 만든 직후 `securityUser.getUser()`를 details에 설정했습니다. `AuthenticationUtil.getLoggedInUser()`는 details에 `User`가 있으면 이를 우선 사용하고, 이전 경로 호환을 위해 principal의 `SecurityUser` fallback은 유지합니다.

## 주요 변경사항
- 폼 로그인 인증 결과 `UsernamePasswordAuthenticationToken.details`에 `User` 설정
- JWT 필터 및 JWT provider 인증 결과 details에 `User` 설정
- Google OAuth 세션 인증 결과 details에 `User` 설정
- `AuthenticationUtil`이 details 기반 사용자 조회를 우선 수행하도록 변경
- provider 단위 테스트 추가 및 JWT provider regression assertion 추가

## Verification method
- 성공: `JAVA_HOME=/home/jiwoo/.sdkman/candidates/java/current PATH=/home/jiwoo/.sdkman/candidates/java/current/bin:$PATH bash ./gradlew test --tests com.omegafrog.My.piano.app.security.provider.CommonUserAuthenticationProviderTest --tests com.omegafrog.My.piano.app.security.provider.JwtAuthenticationProviderTest -x ensureTestInfra`
- 실패(환경): `JAVA_HOME=/home/jiwoo/.sdkman/candidates/java/current PATH=/home/jiwoo/.sdkman/candidates/java/current/bin:$PATH bash ./gradlew build` 실행 시 `ensureTestInfra`에서 WSL `docker-compose` 미설치로 실패

## 테스트/검증 결과
신규/수정 provider 테스트는 성공했습니다. 전체 build는 compile/assemble 이후 테스트 인프라 자동 기동 단계에서 환경 문제로 중단되었습니다.

## 영향 범위 및 리스크
영향 범위는 인증 토큰 생성과 현재 로그인 사용자 조회 경로입니다. principal은 기존처럼 유지해 기존 핸들러/코드 호환성을 보존하고, details에 domain `User`를 추가합니다.

Closes #48