### PR TITLE
[codex] 인증 요청 시 access token 갱신

### DIFF
--- a/src/main/java/com/omegafrog/My/piano/app/security/SecurityConfig.java
+++ b/src/main/java/com/omegafrog/My/piano/app/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.omegafrog.My.piano.app.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.googleapis.auth.oauth2.GooglePublicKeysManager;
+import com.omegafrog.My.piano.app.security.filter.CommonUserJwtTokenFilter;
 import com.omegafrog.My.piano.app.security.handler.*;
 import com.omegafrog.My.piano.app.security.jwt.RefreshTokenRepository;
 import com.omegafrog.My.piano.app.security.jwt.TokenUtils;
@@ -33,6 +34,7 @@ import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -111,6 +113,10 @@ public class SecurityConfig {
   @Bean
   public CommonUserAuthenticationProvider commonUserAuthenticationProvider() {
     return new CommonUserAuthenticationProvider(commonUserService(), passwordEncoder());
+  }
+
+  public CommonUserJwtTokenFilter commonUserJwtTokenFilter() {
+    return new CommonUserJwtTokenFilter(securityUserRepository, refreshTokenRepository, tokenUtils());
   }
 
   @Bean
@@ -239,6 +245,7 @@ public class SecurityConfig {
         .exceptionHandling(ex -> ex
             .authenticationEntryPoint(unAuthorizedEntryPoint())
             .accessDeniedHandler(commonUserAccessDeniedHandler()))
+        .addFilterBefore(commonUserJwtTokenFilter(), UsernamePasswordAuthenticationFilter.class)
         .csrf(AbstractHttpConfigurer::disable)
         .cors(cors -> cors.configurationSource(corsConfigurationSource()));
 

--- a/src/main/java/com/omegafrog/My/piano/app/security/filter/CommonUserJwtTokenFilter.java
+++ b/src/main/java/com/omegafrog/My/piano/app/security/filter/CommonUserJwtTokenFilter.java
@@ -1,6 +1,8 @@
 package com.omegafrog.My.piano.app.security.filter;
 
 import com.omegafrog.My.piano.app.security.jwt.RefreshTokenRepository;
+import com.omegafrog.My.piano.app.security.jwt.RefreshToken;
+import com.omegafrog.My.piano.app.security.jwt.TokenInfo;
 import com.omegafrog.My.piano.app.security.jwt.TokenUtils;
 import com.omegafrog.My.piano.app.web.domain.user.SecurityUserRepository;
 import com.omegafrog.My.piano.app.web.domain.user.authorities.Role;
@@ -12,7 +14,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -28,15 +29,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class CommonUserJwtTokenFilter extends OncePerRequestFilter {
 
     private final SecurityUserRepository securityUserRepository;
     private final RefreshTokenRepository refreshTokenRepository;
-
-    @Autowired
-    private TokenUtils tokenUtils;
+    private final TokenUtils tokenUtils;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -74,20 +74,29 @@ public class CommonUserJwtTokenFilter extends OncePerRequestFilter {
 
         try {
             // token 추출
-            String accessToken = tokenUtils.getAccessTokenString(request.getHeader(HttpHeaders.AUTHORIZATION));
+            String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+            if (authHeader == null || authHeader.isBlank()) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+            String accessToken = tokenUtils.getAccessTokenString(authHeader);
             // token으로부터 유저 추출
             Claims claims = tokenUtils.extractClaims(accessToken);
             Long userId = Long.valueOf((String) claims.get("id"));
             Role role = Role.valueOf(String.valueOf(claims.get("role")));
 
             // refresh token repository에 해당 유저의 refresh token이 없다면 로그아웃한 것.
-            if (refreshTokenRepository.findByRoleAndUserId(userId, role).isEmpty()) {
+            Optional<RefreshToken> refreshToken = refreshTokenRepository.findByRoleAndUserId(userId, role);
+            if (refreshToken.isEmpty()) {
                 throw new BadCredentialsException("Already logged out user.");
             }
             // token validation 진행
             UserDetails user = getUserFromAccessToken(userId);
             Authentication usernameToken = getAuthenticationToken(user);
             SecurityContextHolder.getContext().setAuthentication(usernameToken);
+            TokenInfo tokenInfo = tokenUtils.refreshAccessToken(String.valueOf(userId), role, refreshToken.get());
+            response.setHeader(HttpHeaders.AUTHORIZATION, tokenInfo.getGrantType() + " " + tokenInfo.getAccessToken());
+            response.setHeader(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, HttpHeaders.AUTHORIZATION);
         } catch (ExpiredJwtException e) {
             // 만료되었을 때
             e.printStackTrace();

--- a/src/main/java/com/omegafrog/My/piano/app/security/filter/CommonUserJwtTokenFilter.java
+++ b/src/main/java/com/omegafrog/My/piano/app/security/filter/CommonUserJwtTokenFilter.java
@@ -90,6 +90,9 @@ public class CommonUserJwtTokenFilter extends OncePerRequestFilter {
             if (refreshToken.isEmpty()) {
                 throw new BadCredentialsException("Already logged out user.");
             }
+            if (!tokenUtils.isNonExpired(refreshToken.get().getPayload())) {
+                throw new BadCredentialsException("Refresh token is expired.");
+            }
             // token validation 진행
             UserDetails user = getUserFromAccessToken(userId);
             Authentication usernameToken = getAuthenticationToken(user);

--- a/src/main/java/com/omegafrog/My/piano/app/security/jwt/TokenUtils.java
+++ b/src/main/java/com/omegafrog/My/piano/app/security/jwt/TokenUtils.java
@@ -84,6 +84,15 @@ public class TokenUtils {
                 .build();
     }
 
+    public TokenInfo refreshAccessToken(String securityUserId, Role role, RefreshToken refreshToken) {
+        String accessToken = getToken(securityUserId, role, Long.parseLong(accessTokenExpirationPeriod));
+        return TokenInfo.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
     private boolean verifyAccessTokenString(String[] accessToken) throws AuthenticationException {
         if (accessToken.length == 2) {
             String[] splitted = accessToken[1].split("\\.");

--- a/src/main/java/com/omegafrog/My/piano/app/security/provider/JwtAuthenticationProvider.java
+++ b/src/main/java/com/omegafrog/My/piano/app/security/provider/JwtAuthenticationProvider.java
@@ -42,7 +42,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
 
             SecurityUser user = findUser(securityUserId);
             RefreshToken refreshToken = findRefreshToken(securityUserId, securityUserRole);
-            TokenInfo tokenInfo = tokenUtils.wrap(accessToken, refreshToken);
+            TokenInfo tokenInfo = tokenUtils.refreshAccessToken(String.valueOf(securityUserId), securityUserRole, refreshToken);
             return JwtAuthenticationToken.authenticated(user.getAuthorities(), tokenInfo, securityUserId);
         } catch (ExpiredJwtException e) {
             validateExpiredTokenClaims(e);

--- a/src/main/java/com/omegafrog/My/piano/app/security/provider/JwtAuthenticationProvider.java
+++ b/src/main/java/com/omegafrog/My/piano/app/security/provider/JwtAuthenticationProvider.java
@@ -65,8 +65,12 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
     }
 
     private RefreshToken findRefreshToken(Long securityUserId, Role securityUserRole) {
-        return refreshTokenRepository.findByRoleAndUserId(securityUserId, securityUserRole)
+        RefreshToken refreshToken = refreshTokenRepository.findByRoleAndUserId(securityUserId, securityUserRole)
                 .orElseThrow(() -> new AuthenticationServiceException("Already logged out user."));
+        if (!tokenUtils.isNonExpired(refreshToken.getPayload())) {
+            throw new BadCredentialsException("Refresh token is expired.");
+        }
+        return refreshToken;
     }
 
     private void validateExpiredTokenClaims(ExpiredJwtException e) {

--- a/src/test/java/com/omegafrog/My/piano/app/security/jwt/TokenUtilsTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/security/jwt/TokenUtilsTest.java
@@ -1,0 +1,42 @@
+package com.omegafrog.My.piano.app.security.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.omegafrog.My.piano.app.web.domain.user.authorities.Role;
+
+import io.jsonwebtoken.Claims;
+
+class TokenUtilsTest {
+
+    @Test
+    @DisplayName("기존 refresh token을 유지하면서 access token을 새로 발급해야 한다.")
+    void refreshAccessTokenKeepsRefreshTokenAndIssuesNewAccessToken() {
+        TokenUtils tokenUtils = new TokenUtils();
+        ReflectionTestUtils.setField(tokenUtils, "secret",
+                "abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890bcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890");
+        ReflectionTestUtils.setField(tokenUtils, "accessTokenExpirationPeriod", "60000");
+        RefreshToken refreshToken = RefreshToken.builder()
+                .id("USER-1")
+                .payload("refresh-token")
+                .userId(1L)
+                .role(Role.USER)
+                .expiration(600000L)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        TokenInfo tokenInfo = tokenUtils.refreshAccessToken("1", Role.USER, refreshToken);
+        Claims claims = tokenUtils.extractClaims(tokenInfo.getAccessToken());
+
+        assertThat(tokenInfo.getGrantType()).isEqualTo("Bearer");
+        assertThat(tokenInfo.getRefreshToken()).isSameAs(refreshToken);
+        assertThat(claims.get("id")).isEqualTo("1");
+        assertThat(claims.get("role")).isEqualTo(Role.USER.value);
+        assertThat(claims.getExpiration()).isAfter(claims.getIssuedAt());
+    }
+}

--- a/src/test/java/com/omegafrog/My/piano/app/security/provider/JwtAuthenticationProviderTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/security/provider/JwtAuthenticationProviderTest.java
@@ -3,6 +3,7 @@ package com.omegafrog.My.piano.app.security.provider;
 import com.omegafrog.My.piano.app.security.jwt.JwtAuthenticationToken;
 import com.omegafrog.My.piano.app.security.jwt.RefreshToken;
 import com.omegafrog.My.piano.app.security.jwt.RefreshTokenRepository;
+import com.omegafrog.My.piano.app.security.jwt.TokenInfo;
 import com.omegafrog.My.piano.app.security.jwt.TokenUtils;
 import com.omegafrog.My.piano.app.web.domain.user.SecurityUser;
 import com.omegafrog.My.piano.app.web.domain.user.SecurityUserRepository;
@@ -27,6 +28,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class JwtAuthenticationProviderTest {
@@ -64,6 +66,12 @@ class JwtAuthenticationProviderTest {
         given(tokenUtils.extractClaims("access-token")).willReturn(claims);
         given(securityUserRepository.findById(1L)).willReturn(Optional.of(securityUser));
         given(refreshTokenRepository.findByRoleAndUserId(1L, Role.USER)).willReturn(Optional.of(refreshToken));
+        given(tokenUtils.refreshAccessToken("1", Role.USER, refreshToken))
+                .willReturn(TokenInfo.builder()
+                        .grantType("Bearer")
+                        .accessToken("renewed-access-token")
+                        .refreshToken(refreshToken)
+                        .build());
 
         Authentication authentication = jwtAuthenticationProvider
                 .authenticate(JwtAuthenticationToken.unauthenticated("access-token"));
@@ -71,6 +79,9 @@ class JwtAuthenticationProviderTest {
         assertThat(authentication).isInstanceOf(JwtAuthenticationToken.class);
         assertThat(authentication.isAuthenticated()).isTrue();
         assertThat(authentication.getPrincipal()).isEqualTo(1L);
+        assertThat(((JwtAuthenticationToken) authentication).getTokenInfo().getAccessToken())
+                .isEqualTo("renewed-access-token");
+        verify(tokenUtils).refreshAccessToken("1", Role.USER, refreshToken);
     }
 
     @Test

--- a/src/test/java/com/omegafrog/My/piano/app/security/provider/JwtAuthenticationProviderTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/security/provider/JwtAuthenticationProviderTest.java
@@ -66,6 +66,7 @@ class JwtAuthenticationProviderTest {
         given(tokenUtils.extractClaims("access-token")).willReturn(claims);
         given(securityUserRepository.findById(1L)).willReturn(Optional.of(securityUser));
         given(refreshTokenRepository.findByRoleAndUserId(1L, Role.USER)).willReturn(Optional.of(refreshToken));
+        given(tokenUtils.isNonExpired("refresh")).willReturn(true);
         given(tokenUtils.refreshAccessToken("1", Role.USER, refreshToken))
                 .willReturn(TokenInfo.builder()
                         .grantType("Bearer")
@@ -126,11 +127,41 @@ class JwtAuthenticationProviderTest {
         given(tokenUtils.extractClaims("expired-token")).willThrow(expiredJwtException);
         given(securityUserRepository.findById(1L)).willReturn(Optional.of(securityUser));
         given(refreshTokenRepository.findByRoleAndUserId(1L, Role.USER)).willReturn(Optional.of(refreshToken));
+        given(tokenUtils.isNonExpired("refresh")).willReturn(true);
 
         assertThatThrownBy(() -> jwtAuthenticationProvider
                 .authenticate(JwtAuthenticationToken.unauthenticated("expired-token")))
                 .isInstanceOf(CredentialsExpiredException.class)
                 .hasMessageContaining("expired");
+    }
+
+    @Test
+    @DisplayName("refresh token이 만료되면 access token을 재발급하지 않는다")
+    void authenticateWithExpiredRefreshToken() {
+        Claims claims = claims("1", Role.USER);
+        SecurityUser securityUser = SecurityUser.builder()
+                .username("user1")
+                .password("encoded")
+                .role(Role.USER)
+                .build();
+        RefreshToken refreshToken = RefreshToken.builder()
+                .id("USER-1")
+                .payload("expired-refresh")
+                .userId(1L)
+                .role(Role.USER)
+                .createdAt(LocalDateTime.now())
+                .expiration(1000L)
+                .build();
+
+        given(tokenUtils.extractClaims("access-token")).willReturn(claims);
+        given(securityUserRepository.findById(1L)).willReturn(Optional.of(securityUser));
+        given(refreshTokenRepository.findByRoleAndUserId(1L, Role.USER)).willReturn(Optional.of(refreshToken));
+        given(tokenUtils.isNonExpired("expired-refresh")).willReturn(false);
+
+        assertThatThrownBy(() -> jwtAuthenticationProvider
+                .authenticate(JwtAuthenticationToken.unauthenticated("access-token")))
+                .isInstanceOf(BadCredentialsException.class)
+                .hasMessageContaining("Refresh token is expired");
     }
 
     @Test


### PR DESCRIPTION
## 변경 배경
Issue #60: 로그인 이후 정상 접근 요청을 해도 access token이 갱신되지 않아 만료 시간이 지나면 그대로 만료되는 문제를 수정합니다.

## Implementation intent
유효한 JWT 기반 접근 요청이 들어오면 새 access token을 발급해 응답 헤더로 돌려주고, 서버 내부 JWT 인증 결과도 갱신된 access token을 담도록 합니다.

## Implementation approach
`TokenUtils.refreshAccessToken(...)`을 추가해 기존 refresh token은 유지하면서 access token만 새로 발급합니다. `JwtAuthenticationProvider`는 유효한 access token 인증 시 기존 token을 wrap하지 않고 새 access token을 포함한 `TokenInfo`를 반환합니다. `CommonUserJwtTokenFilter`는 `/api/v1/user/**` 체인에 연결했고, Authorization 헤더가 없는 session 요청은 그대로 통과시키며 Bearer 요청만 검증/인증/갱신합니다. 갱신된 access token은 응답 `Authorization` 헤더로 내려가고, 브라우저에서 읽을 수 있게 expose header도 설정합니다.

## 주요 변경사항
- `TokenUtils`: refresh token 유지 access token 재발급 메서드 추가
- `JwtAuthenticationProvider`: 유효 JWT 인증 시 access token 갱신
- `CommonUserJwtTokenFilter`: Bearer 요청 검증 후 `Authorization` 응답 헤더에 갱신 token 설정, no-header 요청 통과
- `SecurityConfig`: `/api/v1/user/**` 인증 체인에 JWT filter 연결
- `JwtAuthenticationProviderTest`, `TokenUtilsTest`: access token 갱신 동작 검증

## Verification method
- 성공: `JAVA_HOME=/home/jiwoo/.sdkman/candidates/java/current PATH=/home/jiwoo/.sdkman/candidates/java/current/bin:$PATH bash ./gradlew test --tests com.omegafrog.My.piano.app.security.provider.JwtAuthenticationProviderTest --tests com.omegafrog.My.piano.app.security.jwt.TokenUtilsTest -x ensureTestInfra`
- 실패(환경): `JAVA_HOME=/home/jiwoo/.sdkman/candidates/java/current PATH=/home/jiwoo/.sdkman/candidates/java/current/bin:$PATH bash ./gradlew build` 실행 시 `ensureTestInfra`에서 WSL `docker-compose` 미설치로 실패

## 테스트/검증 결과
신규/수정 JWT 단위 테스트는 성공했습니다. 전체 build는 compile/assemble 이후 테스트 인프라 자동 기동 단계에서 환경 문제로 중단되었습니다.

## 영향 범위 및 리스크
영향 범위는 `/api/v1/user/**` JWT Bearer 요청과 `JwtAuthenticationProvider` 인증 경로입니다. Authorization 헤더가 없는 기존 session 기반 요청은 filter가 통과시켜 기존 동작을 유지합니다.

Closes #60