### PR TITLE
검색 입력 제한 및 필터 쿼리 보강

### DIFF
--- a/src/main/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchInstance.java
+++ b/src/main/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchInstance.java
@@ -69,36 +69,36 @@ public class ElasticSearchInstance {
             @Nullable List<String> difficulties,
             @Nullable List<String> genres,
             Pageable pageable) {
-        // multi_match 쿼리 (title, name, content)
-        MultiMatchQuery mmQuery = MultiMatchQuery.of(q -> q
-                .query(searchSentence)
-                .fields("title^5", "name^4", "content^3")
-                .analyzer("my_nori_analyzer")
-                .minimumShouldMatch("2<75%"));
-
-        // bool should
         BoolQuery boolQuery = BoolQuery.of(b -> {
-            b.should(mmQuery._toQuery());
+            if (searchSentence == null || searchSentence.isBlank()) {
+                b.must(QueryBuilders.matchAll().build()._toQuery());
+            } else {
+                b.must(MultiMatchQuery.of(q -> q
+                        .query(searchSentence)
+                        .fields("title^5", "name^4", "content^3")
+                        .analyzer("my_nori_analyzer")
+                        .minimumShouldMatch("2<75%"))._toQuery());
+            }
 
             if (genres != null && !genres.isEmpty()) {
-                b.should(TermsQuery.of(t -> t
+                b.filter(TermsQuery.of(t -> t
                         .field("genre")
-                        .terms(TermsQueryField.of(f -> f.value(genres.stream().map(FieldValue::of).toList())))
-                        .boost(1.5f))._toQuery());
+                        .terms(TermsQueryField.of(f -> f.value(genres.stream().map(FieldValue::of).toList()))))
+                        ._toQuery());
             }
 
             if (difficulties != null && !difficulties.isEmpty()) {
-                b.should(TermsQuery.of(t -> t
+                b.filter(TermsQuery.of(t -> t
                         .field("difficulty")
-                        .terms(TermsQueryField.of(f -> f.value(difficulties.stream().map(FieldValue::of).toList())))
-                        .boost(1.2f))._toQuery());
+                        .terms(TermsQueryField.of(f -> f.value(difficulties.stream().map(FieldValue::of).toList()))))
+                        ._toQuery());
             }
 
             if (instruments != null && !instruments.isEmpty()) {
-                b.should(TermsQuery.of(t -> t
+                b.filter(TermsQuery.of(t -> t
                         .field("instrument")
-                        .terms(TermsQueryField.of(f -> f.value(instruments.stream().map(FieldValue::of).toList())))
-                        .boost(1.5f))._toQuery());
+                        .terms(TermsQueryField.of(f -> f.value(instruments.stream().map(FieldValue::of).toList()))))
+                        ._toQuery());
             }
 
             return b;
@@ -246,27 +246,24 @@ public class ElasticSearchInstance {
             // keyword 자동완성
             b.must(mmQuery._toQuery());
 
-            // instrument 필터
             if (instruments != null && !instruments.isEmpty()) {
-                b.must(TermsQuery.of(t -> t
+                b.filter(TermsQuery.of(t -> t
                         .field("instrument")
                         .terms(TermsQueryField.of(f -> f.value(
                                 instruments.stream().map(FieldValue::of).collect(Collectors.toList())))))
                         ._toQuery());
             }
 
-            // genre 필터
             if (genres != null && !genres.isEmpty()) {
-                b.must(TermsQuery.of(t -> t
+                b.filter(TermsQuery.of(t -> t
                         .field("genre")
                         .terms(TermsQueryField.of(f -> f.value(
                                 genres.stream().map(FieldValue::of).collect(Collectors.toList())))))
                         ._toQuery());
             }
 
-            // difficulty 필터
             if (difficulties != null && !difficulties.isEmpty()) {
-                b.must(TermsQuery.of(t -> t
+                b.filter(TermsQuery.of(t -> t
                         .field("difficulty")
                         .terms(TermsQueryField.of(f -> f.value(
                                 difficulties.stream().map(FieldValue::of).collect(Collectors.toList())))))

--- a/src/main/java/com/omegafrog/My/piano/app/web/controller/ExceptionAdvisor.java
+++ b/src/main/java/com/omegafrog/My/piano/app/web/controller/ExceptionAdvisor.java
@@ -73,6 +73,7 @@ public class ExceptionAdvisor {
     @ExceptionHandler({
             EntityNotFoundException.class,
             EntityExistsException.class, PaymentException.class,
+            IllegalArgumentException.class,
             DuplicatePropertyException.class})
     public Object clientRequestError(RuntimeException ex) {
         apiExceptionLogger.logHandledException(ex, HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/omegafrog/My/piano/app/web/service/SheetPostApplicationService.java
+++ b/src/main/java/com/omegafrog/My/piano/app/web/service/SheetPostApplicationService.java
@@ -309,6 +309,12 @@ public class SheetPostApplicationService {
 			List<String> genre,
 			SheetPostSearchBackend searchBackend,
 			Pageable pageable) {
+		searchSentence = SheetPostSearchRequestGuard.normalizeSearchSentence(searchSentence);
+		instrument = SheetPostSearchRequestGuard.normalizeFilterValues(instrument);
+		difficulty = SheetPostSearchRequestGuard.normalizeFilterValues(difficulty);
+		genre = SheetPostSearchRequestGuard.normalizeFilterValues(genre);
+		SheetPostSearchRequestGuard.validateListRequest(searchSentence, instrument, difficulty, genre, pageable);
+
 		SheetPostListCacheKey cacheKey = SheetPostListCacheKey.of(
 				searchSentence,
 				instrument,
@@ -403,6 +409,15 @@ public class SheetPostApplicationService {
 
 	public List<SheetPostListDto> getSheetPostAutoComplete(String searchSentence, List<String> instrument,
 			List<String> difficulty, List<String> genre) {
+		searchSentence = SheetPostSearchRequestGuard.normalizeSearchSentence(searchSentence);
+		instrument = SheetPostSearchRequestGuard.normalizeFilterValues(instrument);
+		difficulty = SheetPostSearchRequestGuard.normalizeFilterValues(difficulty);
+		genre = SheetPostSearchRequestGuard.normalizeFilterValues(genre);
+		SheetPostSearchRequestGuard.validateAutocompleteRequest(searchSentence, instrument, difficulty, genre);
+		if (!SheetPostSearchRequestGuard.isAutocompleteQueryAllowed(searchSentence)) {
+			return List.of();
+		}
+
 		List<SheetPostIndex> result = elasticSearchInstance.getSearchSheetPostAutoComplete(searchSentence, instrument,
 				difficulty, genre);
 		return sheetPostRepository.findAllById(result.stream().map(item -> item.getId()).toList())

--- a/src/main/java/com/omegafrog/My/piano/app/web/service/SheetPostSearchRequestGuard.java
+++ b/src/main/java/com/omegafrog/My/piano/app/web/service/SheetPostSearchRequestGuard.java
@@ -1,0 +1,86 @@
+package com.omegafrog.My.piano.app.web.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+
+final class SheetPostSearchRequestGuard {
+
+	static final int MAX_SEARCH_SENTENCE_LENGTH = 100;
+	static final int MAX_PAGE_SIZE = 50;
+	static final int MAX_PAGE_NUMBER = 100;
+	static final int MAX_FILTER_VALUES = 10;
+	static final int MIN_AUTOCOMPLETE_SEARCH_LENGTH = 2;
+
+	private SheetPostSearchRequestGuard() {
+	}
+
+	static void validateListRequest(
+			String searchSentence,
+			List<String> instrument,
+			List<String> difficulty,
+			List<String> genre,
+			Pageable pageable) {
+		validateSearchSentence(searchSentence);
+		validatePageable(pageable);
+		validateFilterValues("instrument", instrument);
+		validateFilterValues("difficulty", difficulty);
+		validateFilterValues("genre", genre);
+	}
+
+	static void validateAutocompleteRequest(
+			String searchSentence,
+			List<String> instrument,
+			List<String> difficulty,
+			List<String> genre) {
+		validateSearchSentence(searchSentence);
+		validateFilterValues("instrument", instrument);
+		validateFilterValues("difficulty", difficulty);
+		validateFilterValues("genre", genre);
+	}
+
+	static boolean isAutocompleteQueryAllowed(String searchSentence) {
+		return searchSentence != null && searchSentence.length() >= MIN_AUTOCOMPLETE_SEARCH_LENGTH;
+	}
+
+	static String normalizeSearchSentence(String searchSentence) {
+		if (searchSentence == null) {
+			return null;
+		}
+		String trimmed = searchSentence.trim();
+		return trimmed.isEmpty() ? null : trimmed;
+	}
+
+	static List<String> normalizeFilterValues(List<String> values) {
+		if (values == null) {
+			return null;
+		}
+		List<String> normalized = values.stream()
+				.filter(value -> value != null && !value.isBlank())
+				.map(String::trim)
+				.distinct()
+				.toList();
+		return normalized.isEmpty() ? null : normalized;
+	}
+
+	private static void validateSearchSentence(String searchSentence) {
+		if (searchSentence != null && searchSentence.length() > MAX_SEARCH_SENTENCE_LENGTH) {
+			throw new IllegalArgumentException("searchSentence must be " + MAX_SEARCH_SENTENCE_LENGTH + " characters or less.");
+		}
+	}
+
+	private static void validatePageable(Pageable pageable) {
+		if (pageable.getPageSize() > MAX_PAGE_SIZE) {
+			throw new IllegalArgumentException("page size must be " + MAX_PAGE_SIZE + " or less.");
+		}
+		if (pageable.getPageNumber() > MAX_PAGE_NUMBER) {
+			throw new IllegalArgumentException("page number must be " + MAX_PAGE_NUMBER + " or less.");
+		}
+	}
+
+	private static void validateFilterValues(String fieldName, List<String> values) {
+		if (values != null && values.size() > MAX_FILTER_VALUES) {
+			throw new IllegalArgumentException(fieldName + " filter count must be " + MAX_FILTER_VALUES + " or less.");
+		}
+	}
+}

--- a/src/test/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchInstanceTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchInstanceTest.java
@@ -1,0 +1,74 @@
+package com.omegafrog.My.piano.app.external.elasticsearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.PageRequest;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
+
+class ElasticSearchInstanceTest {
+
+	private final ElasticsearchClient client = mock(ElasticsearchClient.class);
+	private final ElasticSearchInstance elasticSearchInstance = new ElasticSearchInstance(client);
+
+	@Test
+	void searchSheetPostUsesFilterClausesForFacetInputs() throws IOException {
+		when(client.search(org.mockito.ArgumentMatchers.any(SearchRequest.class), eq(SheetPostIndex.class)))
+				.thenReturn(emptyResponse());
+
+		elasticSearchInstance.searchSheetPost(
+				"mozart",
+				List.of("PIANO"),
+				List.of("EASY"),
+				List.of("CLASSIC"),
+				PageRequest.of(0, 20));
+
+		BoolQuery boolQuery = capturedSearchRequest().query().functionScore().query().bool();
+
+		assertThat(boolQuery.must()).hasSize(1);
+		assertThat(boolQuery.filter()).hasSize(3);
+		assertThat(boolQuery.should()).isEmpty();
+	}
+
+	@Test
+	void searchSheetPostUsesMatchAllForBlankSearchSentence() throws IOException {
+		when(client.search(org.mockito.ArgumentMatchers.any(SearchRequest.class), eq(SheetPostIndex.class)))
+				.thenReturn(emptyResponse());
+
+		elasticSearchInstance.searchSheetPost(null, null, null, null, PageRequest.of(0, 20));
+
+		Query baseQuery = capturedSearchRequest().query().functionScore().query().bool().must().get(0);
+
+		assertThat(baseQuery.isMatchAll()).isTrue();
+	}
+
+	private SearchRequest capturedSearchRequest() throws IOException {
+		ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+		verify(client).search(captor.capture(), eq(SheetPostIndex.class));
+		return captor.getValue();
+	}
+
+	private SearchResponse<SheetPostIndex> emptyResponse() {
+		return SearchResponse.of(response -> response
+				.took(1)
+				.timedOut(false)
+				.shards(shards -> shards.total(1).successful(1).failed(0))
+				.hits(hits -> hits
+						.total(total -> total.value(0).relation(TotalHitsRelation.Eq))
+						.hits(List.of())));
+	}
+}

--- a/src/test/java/com/omegafrog/My/piano/app/web/service/SheetPostSearchRequestGuardTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/web/service/SheetPostSearchRequestGuardTest.java
@@ -1,0 +1,65 @@
+package com.omegafrog.My.piano.app.web.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+
+class SheetPostSearchRequestGuardTest {
+
+	@Test
+	void normalizesBlankSearchSentenceToNull() {
+		assertThat(SheetPostSearchRequestGuard.normalizeSearchSentence("   ")).isNull();
+	}
+
+	@Test
+	void normalizesBlankFilterValuesToNull() {
+		assertThat(SheetPostSearchRequestGuard.normalizeFilterValues(List.of(" ", "\t"))).isNull();
+	}
+
+	@Test
+	void rejectsOversizedSearchSentence() {
+		String tooLong = "a".repeat(SheetPostSearchRequestGuard.MAX_SEARCH_SENTENCE_LENGTH + 1);
+
+		assertThatThrownBy(() -> SheetPostSearchRequestGuard.validateListRequest(
+				tooLong, null, null, null, PageRequest.of(0, 20)))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("searchSentence");
+	}
+
+	@Test
+	void rejectsOversizedPageRequest() {
+		assertThatThrownBy(() -> SheetPostSearchRequestGuard.validateListRequest(
+				null, null, null, null, PageRequest.of(0, SheetPostSearchRequestGuard.MAX_PAGE_SIZE + 1)))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("page size");
+	}
+
+	@Test
+	void rejectsDeepPageRequest() {
+		assertThatThrownBy(() -> SheetPostSearchRequestGuard.validateListRequest(
+				null, null, null, null, PageRequest.of(SheetPostSearchRequestGuard.MAX_PAGE_NUMBER + 1, 20)))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("page number");
+	}
+
+	@Test
+	void rejectsTooManyFilterValues() {
+		List<String> filters = java.util.stream.IntStream.rangeClosed(1, SheetPostSearchRequestGuard.MAX_FILTER_VALUES + 1)
+				.mapToObj(index -> "filter-" + index)
+				.toList();
+
+		assertThatThrownBy(() -> SheetPostSearchRequestGuard.validateAutocompleteRequest("aa", filters, null, null))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("instrument filter count");
+	}
+
+	@Test
+	void autocompleteRequiresMinimumSearchLength() {
+		assertThat(SheetPostSearchRequestGuard.isAutocompleteQueryAllowed("a")).isFalse();
+		assertThat(SheetPostSearchRequestGuard.isAutocompleteQueryAllowed("aa")).isTrue();
+	}
+}


### PR DESCRIPTION
## 변경 배경
- Closes #95
- 악보 검색 API에서 검색어가 비어 있는 경우의 동작이 명확하지 않고, 필터 조건이 Elasticsearch `should` 절에 들어가 필터가 아닌 점수 보정처럼 동작할 수 있었습니다.
- 공개 검색 API에 검색어 길이, 페이지 크기/깊이, 필터 개수 제한이 없어 과도한 요청을 제한하기 어려웠습니다.

## 주요 변경사항
- `SheetPostSearchRequestGuard`를 추가해 검색어/필터를 정규화하고 요청 제한을 검증합니다.
  - `searchSentence`는 trim 후 blank면 `null`로 정규화합니다.
  - 검색어는 최대 100자, 페이지 크기는 최대 50, 페이지 번호는 최대 100, 필터 값은 각 항목별 최대 10개로 제한합니다.
  - 자동완성은 정규화된 검색어가 2자 미만이면 Elasticsearch 호출 없이 빈 결과를 반환합니다.
- `SheetPostApplicationService`에서 검색/자동완성 진입 시점에 입력을 정규화하고 검증하도록 연결했습니다.
- `ElasticSearchInstance`에서 악보 검색의 장르/난이도/악기 조건을 `should`가 아닌 `filter` 절로 적용하도록 변경했습니다.
- blank 검색어는 `match_all` 기반 검색으로 정의해 필터만 있는 검색도 일관되게 처리합니다.
- `IllegalArgumentException`을 400 응답으로 매핑해 공개 API 입력 제한 위반이 클라이언트 오류로 반환되게 했습니다.

## Implementation intent
- 검색 API가 필터 조건을 실제 필터로 처리하고, 공개 입력값에 명시적인 제한을 두도록 구현합니다.

## Implementation approach
- 요청 진입점에서 검색어와 필터 리스트를 정규화한 뒤 제한을 검증합니다.
- 서비스는 정규화된 값을 캐시 키, DB/ES 검색, 검색 이벤트 발행에 동일하게 전달합니다.
- Elasticsearch 쿼리는 검색어가 있으면 `multi_match`를 `must`에 넣고, 검색어가 없으면 `match_all`을 `must`에 넣습니다.
- 장르/난이도/악기 조건은 `filter` 절에 추가해 점수 계산과 분리합니다.
- 자동완성은 최소 검색어 길이 미만 요청을 조기 반환해 불필요한 ES 요청을 막습니다.

## Verification method
- 신규 요청 제한 단위 테스트로 검색어 길이, 페이지 크기/깊이, 필터 개수, blank 정규화, 자동완성 최소 길이를 검증했습니다.
- Elasticsearch 단위 테스트로 필터 조건이 `filter` 절에 들어가고 `should` 절이 비어 있는지 검증했습니다.
- blank 검색어가 `match_all` 기반 쿼리로 생성되는지 검증했습니다.

## 테스트/검증 결과
- PASS: `JAVA_HOME=/home/jiwoo/.sdkman/candidates/java/current PATH=/home/jiwoo/.sdkman/candidates/java/current/bin:$PATH bash ./gradlew test --tests 'com.omegafrog.My.piano.app.web.service.SheetPostSearchRequestGuardTest' --tests 'com.omegafrog.My.piano.app.external.elasticsearch.ElasticSearchInstanceTest' -x ensureTestInfra`
- FAIL: `JAVA_HOME=/home/jiwoo/.sdkman/candidates/java/current PATH=/home/jiwoo/.sdkman/candidates/java/current/bin:$PATH bash ./gradlew build`
  - `ensureTestInfra`에서 WSL 환경에 `docker-compose`가 없어 실패했습니다.
- FAIL: `JAVA_HOME=/home/jiwoo/.sdkman/candidates/java/current PATH=/home/jiwoo/.sdkman/candidates/java/current/bin:$PATH bash ./gradlew build -x ensureTestInfra`
  - 전체 테스트 중 기존 Spring 통합/Repository 테스트가 MySQL 연결 실패 및 캐시 설정 실패로 실패했습니다.

## 영향 범위 및 리스크
- 영향 범위는 악보 검색/자동완성 API 입력 처리와 Elasticsearch 쿼리 생성입니다.
- 검색 필터는 더 이상 점수 보정으로 동작하지 않고 결과 제한 조건으로 동작합니다.
- 새 제한보다 큰 공개 API 요청은 400 응답을 받습니다.
