### PR TITLE
Elasticsearch 장애 대응 및 관측성 보강

### DIFF
--- a/src/main/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchConfig.java
+++ b/src/main/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchConfig.java
@@ -27,6 +27,12 @@ public class ElasticSearchConfig {
     private String port;
     @Value("${elasticsearch.apiKey}")
     private String apiKey;
+    @Value("${elasticsearch.connectTimeoutMillis:1000}")
+    private int connectTimeoutMillis;
+    @Value("${elasticsearch.socketTimeoutMillis:3000}")
+    private int socketTimeoutMillis;
+    @Value("${elasticsearch.connectionRequestTimeoutMillis:1000}")
+    private int connectionRequestTimeoutMillis;
 
     @Bean
     public ElasticsearchClient elasticsearchClient(ObjectMapper objectMapper) {
@@ -38,6 +44,10 @@ public class ElasticSearchConfig {
                 .setDefaultHeaders(new Header[]{
                         new BasicHeader("Authorization", "ApiKey " + apiKey)
                 })
+                .setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder
+                        .setConnectTimeout(connectTimeoutMillis)
+                        .setSocketTimeout(socketTimeoutMillis)
+                        .setConnectionRequestTimeout(connectionRequestTimeoutMillis))
                 .build();
 
         // Create the transport with a Jackson mapper

--- a/src/main/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchInstance.java
+++ b/src/main/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchInstance.java
@@ -31,6 +31,7 @@ import org.springframework.data.util.Pair;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+import io.micrometer.core.instrument.Timer;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.time.ZoneOffset;
@@ -56,12 +57,24 @@ public class ElasticSearchInstance {
 
     @Async("ThreadPoolTaskExecutor")
     public void invertIndexingSheetPost(SheetPost sheetPost) {
-        sheetPostIndexRepository.save(SheetPostIndex.of(sheetPost));
+        try {
+            sheetPostIndexRepository.save(SheetPostIndex.of(sheetPost));
+            ElasticSearchOperationMetrics.recordIndexingSuccess("sheet_post");
+        } catch (RuntimeException e) {
+            ElasticSearchOperationMetrics.recordIndexingError("sheet_post");
+            throw e;
+        }
     }
 
     @Async("ThreadPoolTaskExecutor")
     public void invertIndexingSheetPost(SheetPostIndex index) {
-        sheetPostIndexRepository.save(index);
+        try {
+            sheetPostIndexRepository.save(index);
+            ElasticSearchOperationMetrics.recordIndexingSuccess("sheet_post");
+        } catch (RuntimeException e) {
+            ElasticSearchOperationMetrics.recordIndexingError("sheet_post");
+            throw e;
+        }
     }
 
     public Pair<Page<Long>, String> searchSheetPost(@Nullable String searchSentence,
@@ -121,14 +134,21 @@ public class ElasticSearchInstance {
                 .from((int) pageable.getOffset())
                 .size(pageable.getPageSize()));
 
+        Timer.Sample sample = ElasticSearchOperationMetrics.startSearchTimer();
         SearchResponse<SheetPostIndex> response = null;
         try {
             response = client.search(searchRequest, SheetPostIndex.class);
         } catch (IOException e) {
+            ElasticSearchOperationMetrics.recordSearchError("sheet_post_search", sample);
             throw new ElasticSearchException("elasticsearch query failed. query:" + searchRequest.query().toString(),
                     e);
         }
+        if (response.timedOut()) {
+            ElasticSearchOperationMetrics.recordSearchTimeout("sheet_post_search", sample);
+            throw new ElasticSearchException("elasticsearch query timed out. query:" + searchRequest.query().toString());
+        }
         long count = response.hits().total().value();
+        ElasticSearchOperationMetrics.recordSearchSuccess("sheet_post_search", sample, count == 0);
 
         List<Hit<SheetPostIndex>> hits = response.hits().hits();
         List<Long> sheetPostIds = new ArrayList<>();
@@ -292,14 +312,21 @@ public class ElasticSearchInstance {
                 .query(functionScoreQuery._toQuery())
                 .size(AUTOCOMPLETE_SIZE));
 
+        Timer.Sample sample = ElasticSearchOperationMetrics.startSearchTimer();
         SearchResponse<SheetPostIndex> response = null;
         try {
             response = client.search(searchRequest, SheetPostIndex.class);
         } catch (IOException e) {
+            ElasticSearchOperationMetrics.recordSearchError("sheet_post_autocomplete", sample);
             throw new ElasticSearchException("sheetpostindex search failed", e);
+        }
+        if (response.timedOut()) {
+            ElasticSearchOperationMetrics.recordSearchTimeout("sheet_post_autocomplete", sample);
+            throw new ElasticSearchException("sheetpostindex search timed out");
         }
 
         List<Hit<SheetPostIndex>> hits = response.hits().hits();
+        ElasticSearchOperationMetrics.recordSearchSuccess("sheet_post_autocomplete", sample, hits.isEmpty());
         return hits.stream().map(Hit::source).toList();
     }
 

--- a/src/main/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchOperationMetrics.java
+++ b/src/main/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchOperationMetrics.java
@@ -1,0 +1,62 @@
+package com.omegafrog.My.piano.app.external.elasticsearch;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+
+public final class ElasticSearchOperationMetrics {
+
+	private static final String SEARCH_LATENCY = "mypiano.elasticsearch.search.latency";
+	private static final String SEARCH_REQUESTS = "mypiano.elasticsearch.search.requests";
+	private static final String SEARCH_EMPTY_HITS = "mypiano.elasticsearch.search.empty_hits";
+	private static final String SEARCH_FALLBACKS = "mypiano.elasticsearch.search.fallbacks";
+	private static final String INDEXING_REQUESTS = "mypiano.elasticsearch.indexing.requests";
+
+	private ElasticSearchOperationMetrics() {
+	}
+
+	static Timer.Sample startSearchTimer() {
+		return Timer.start(Metrics.globalRegistry);
+	}
+
+	static void recordSearchSuccess(String operation, Timer.Sample sample, boolean emptyHits) {
+		recordSearch(operation, sample, "success");
+		if (emptyHits) {
+			counter(SEARCH_EMPTY_HITS, "operation", operation).increment();
+		}
+	}
+
+	static void recordSearchTimeout(String operation, Timer.Sample sample) {
+		recordSearch(operation, sample, "timeout");
+	}
+
+	static void recordSearchError(String operation, Timer.Sample sample) {
+		recordSearch(operation, sample, "error");
+	}
+
+	public static void recordSearchFallback(Throwable cause) {
+		counter(SEARCH_FALLBACKS, "reason", cause.getClass().getSimpleName()).increment();
+	}
+
+	static void recordIndexingSuccess(String operation) {
+		counter(INDEXING_REQUESTS, "operation", operation, "outcome", "success").increment();
+	}
+
+	static void recordIndexingError(String operation) {
+		counter(INDEXING_REQUESTS, "operation", operation, "outcome", "error").increment();
+	}
+
+	private static void recordSearch(String operation, Timer.Sample sample, String outcome) {
+		sample.stop(Timer.builder(SEARCH_LATENCY)
+				.tag("operation", operation)
+				.tag("outcome", outcome)
+				.register(Metrics.globalRegistry));
+		counter(SEARCH_REQUESTS, "operation", operation, "outcome", outcome).increment();
+	}
+
+	private static Counter counter(String name, String... tags) {
+		return Counter.builder(name)
+				.tags(tags)
+				.register(Metrics.globalRegistry);
+	}
+}

--- a/src/main/java/com/omegafrog/My/piano/app/external/elasticsearch/exception/ElasticSearchException.java
+++ b/src/main/java/com/omegafrog/My/piano/app/external/elasticsearch/exception/ElasticSearchException.java
@@ -1,6 +1,10 @@
 package com.omegafrog.My.piano.app.external.elasticsearch.exception;
 
 public class ElasticSearchException extends RuntimeException {
+  public ElasticSearchException(String message) {
+    super(message);
+  }
+
   public ElasticSearchException(String message, Throwable e) {
     super(message, e);
   }

--- a/src/main/java/com/omegafrog/My/piano/app/web/service/SheetPostApplicationService.java
+++ b/src/main/java/com/omegafrog/My/piano/app/web/service/SheetPostApplicationService.java
@@ -24,6 +24,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.omegafrog.My.piano.app.external.elasticsearch.ElasticSearchInstance;
+import com.omegafrog.My.piano.app.external.elasticsearch.ElasticSearchOperationMetrics;
+import com.omegafrog.My.piano.app.external.elasticsearch.exception.ElasticSearchException;
 import com.omegafrog.My.piano.app.external.elasticsearch.SheetPostIndex;
 import com.omegafrog.My.piano.app.external.elasticsearch.SheetPostIndexRepository;
 import com.omegafrog.My.piano.app.utils.AuthenticationUtil;
@@ -452,12 +454,30 @@ public class SheetPostApplicationService {
 			List<String> genre,
 			Pageable pageable
 	) {
-		Pair<Page<Long>, String> pairs = elasticSearchInstance.searchSheetPost(
+		Pair<Page<Long>, String> pairs;
+		try {
+			pairs = elasticSearchInstance.searchSheetPost(
+						searchSentence,
+						instrument,
+						difficulty,
+						genre,
+						pageable);
+		} catch (ElasticSearchException e) {
+			ElasticSearchOperationMetrics.recordSearchFallback(e);
+			log.warn("Falling back to DB sheet post search because Elasticsearch search failed. sentence={}, page={}",
+					searchSentence, pageable.getPageNumber(), e);
+			SheetPostListCachePayload fallback = loadSheetPostListPayloadDb(
 					searchSentence,
 					instrument,
 					difficulty,
 					genre,
 					pageable);
+			return new SheetPostListCachePayload(
+					fallback.items(),
+					fallback.totalElements(),
+					"es-fallback[reason=" + e.getClass().getSimpleName() + "," + fallback.rawQuery() + "]"
+			);
+		}
 		Page<Long> sheetPostIds = pairs.getFirst();
 		String rawQuery = pairs.getSecond();
 		List<SheetPostListDto> rows = sheetPostIds.getContent().isEmpty()

--- a/src/test/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchInstanceResilienceTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/external/elasticsearch/ElasticSearchInstanceResilienceTest.java
@@ -1,0 +1,70 @@
+package com.omegafrog.My.piano.app.external.elasticsearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+
+import com.omegafrog.My.piano.app.external.elasticsearch.exception.ElasticSearchException;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class ElasticSearchInstanceResilienceTest {
+
+	private SimpleMeterRegistry registry;
+
+	@BeforeEach
+	void setUp() {
+		registry = new SimpleMeterRegistry();
+		Metrics.addRegistry(registry);
+	}
+
+	@AfterEach
+	void tearDown() {
+		Metrics.removeRegistry(registry);
+		registry.close();
+	}
+
+	@Test
+	void searchSheetPostRecordsTimeoutAndThrowsWhenElasticsearchTimesOut() throws IOException {
+		ElasticsearchClient client = mock(ElasticsearchClient.class);
+		ElasticSearchInstance elasticSearchInstance = new ElasticSearchInstance(client);
+		when(client.search(any(SearchRequest.class), eq(SheetPostIndex.class)))
+				.thenReturn(searchResponse(true));
+
+		assertThatThrownBy(() -> elasticSearchInstance.searchSheetPost(
+				"bach", null, null, null, PageRequest.of(0, 20)))
+				.isInstanceOf(ElasticSearchException.class)
+				.hasMessageContaining("timed out");
+
+		assertThat(registry.counter(
+				"mypiano.elasticsearch.search.requests",
+				"operation", "sheet_post_search",
+				"outcome", "timeout").count()).isEqualTo(1.0);
+	}
+
+	private SearchResponse<SheetPostIndex> searchResponse(boolean timedOut) {
+		return SearchResponse.of(response -> response
+				.took(1000)
+				.timedOut(timedOut)
+				.shards(shards -> shards.total(1).successful(1).failed(0))
+				.hits(hits -> hits
+						.total(total -> total.value(0).relation(TotalHitsRelation.Eq))
+						.hits(List.of())));
+	}
+}

--- a/src/test/java/com/omegafrog/My/piano/app/web/service/SheetPostApplicationServiceSearchFallbackTest.java
+++ b/src/test/java/com/omegafrog/My/piano/app/web/service/SheetPostApplicationServiceSearchFallbackTest.java
@@ -1,0 +1,123 @@
+package com.omegafrog.My.piano.app.web.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.omegafrog.My.piano.app.external.elasticsearch.ElasticSearchInstance;
+import com.omegafrog.My.piano.app.external.elasticsearch.SheetPostIndexRepository;
+import com.omegafrog.My.piano.app.external.elasticsearch.exception.ElasticSearchException;
+import com.omegafrog.My.piano.app.cache.SingleFlightCoordinator;
+import com.omegafrog.My.piano.app.utils.AuthenticationUtil;
+import com.omegafrog.My.piano.app.web.domain.FileStorageExecutor;
+import com.omegafrog.My.piano.app.web.domain.sheet.SheetPostRepository;
+import com.omegafrog.My.piano.app.web.domain.sheet.SheetPostViewCountRepository;
+import com.omegafrog.My.piano.app.web.domain.user.UserRepository;
+import com.omegafrog.My.piano.app.web.dto.sheetPost.SheetPostListDto;
+import com.omegafrog.My.piano.app.web.enums.Difficulty;
+import com.omegafrog.My.piano.app.web.enums.Instrument;
+import com.omegafrog.My.piano.app.web.enums.SheetPostSearchBackend;
+import com.omegafrog.My.piano.app.web.service.cache.SheetPostCacheCoordinator;
+import com.omegafrog.My.piano.app.web.service.outbox.SheetPostOutboxService;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class SheetPostApplicationServiceSearchFallbackTest {
+
+	private final SheetPostIndexRepository sheetPostIndexRepository = mock(SheetPostIndexRepository.class);
+	private final SheetPostRepository sheetPostRepository = mock(SheetPostRepository.class);
+	private final UserRepository userRepository = mock(UserRepository.class);
+	private final ElasticSearchInstance elasticSearchInstance = mock(ElasticSearchInstance.class);
+	private final FileStorageExecutor fileStorageExecutor = mock(FileStorageExecutor.class);
+	private final SheetPostViewCountRepository sheetPostViewCountRepository = mock(SheetPostViewCountRepository.class);
+	private final AuthenticationUtil authenticationUtil = mock(AuthenticationUtil.class);
+	private final FileUploadService fileUploadService = mock(FileUploadService.class);
+	private final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+	private final SheetPostOutboxService sheetPostOutboxService = mock(SheetPostOutboxService.class);
+	private final ObjectProvider<Executor> executorProvider = mock(ObjectProvider.class);
+
+	private SimpleMeterRegistry registry;
+	private SheetPostApplicationService service;
+
+	@BeforeEach
+	void setUp() {
+		registry = new SimpleMeterRegistry();
+		Metrics.addRegistry(registry);
+		when(executorProvider.getIfAvailable()).thenReturn(Executors.newSingleThreadExecutor());
+		SheetPostCacheCoordinator cacheCoordinator = new SheetPostCacheCoordinator(
+				new ConcurrentMapCacheManager("sheetpostList", "sheetpostDetail"),
+				new SingleFlightCoordinator(),
+				executorProvider);
+		service = new SheetPostApplicationService(
+				sheetPostIndexRepository,
+				sheetPostRepository,
+				userRepository,
+				elasticSearchInstance,
+				fileStorageExecutor,
+				sheetPostViewCountRepository,
+				authenticationUtil,
+				fileUploadService,
+				eventPublisher,
+				sheetPostOutboxService,
+				cacheCoordinator);
+	}
+
+	@AfterEach
+	void tearDown() {
+		Metrics.removeRegistry(registry);
+		registry.close();
+	}
+
+	@Test
+	void getSheetPostsFallsBackToDbWhenElasticsearchFails() {
+		Pageable pageable = PageRequest.of(0, 20);
+		SheetPostListDto row = new SheetPostListDto(
+				1L,
+				"title",
+				"artist",
+				"profile",
+				"sheet",
+				Difficulty.EASY,
+				null,
+				Instrument.PIANO_KEY_88,
+				java.time.LocalDateTime.now(),
+				1000);
+		when(elasticSearchInstance.searchSheetPost(eq("bach"), any(), any(), any(), eq(pageable)))
+				.thenThrow(new ElasticSearchException("timeout"));
+		when(sheetPostRepository.searchSheetPosts(eq("bach"), any(), any(), any(), eq(pageable)))
+				.thenReturn(new PageImpl<>(List.of(row), pageable, 1));
+		when(sheetPostViewCountRepository.getViewCountsByIds(anyList())).thenReturn(Map.of(1L, 3));
+
+		Page<SheetPostListDto> result = service.getSheetPosts(
+				"bach", null, null, null, SheetPostSearchBackend.ES, pageable);
+
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent().get(0).getTitle()).isEqualTo("title");
+		assertThat(result.getContent().get(0).getViewCount()).isEqualTo(3);
+		assertThat(registry.counter(
+				"mypiano.elasticsearch.search.fallbacks",
+				"reason", "ElasticSearchException").count()).isEqualTo(1.0);
+		verify(sheetPostRepository).searchSheetPosts(eq("bach"), any(), any(), any(), eq(pageable));
+	}
+}


### PR DESCRIPTION
## 변경 배경
- Closes #96
- 악보 검색 경로에서 Elasticsearch 지연/장애가 발생하면 사용자 API latency와 availability에 직접 영향을 줄 수 있었습니다.
- ES timeout/error/fallback/empty hit 추이를 볼 수 있는 메트릭도 부족했습니다.

## 주요 변경사항
- `ElasticSearchConfig`에 Elasticsearch client timeout 설정을 추가했습니다.
  - `elasticsearch.connectTimeoutMillis` 기본값 1000ms
  - `elasticsearch.socketTimeoutMillis` 기본값 3000ms
  - `elasticsearch.connectionRequestTimeoutMillis` 기본값 1000ms
- `ElasticSearchOperationMetrics`를 추가해 Micrometer global registry 기반 메트릭을 기록합니다.
  - 검색 latency timer: `mypiano.elasticsearch.search.latency`
  - 검색 결과 counter: `mypiano.elasticsearch.search.requests`
  - empty hit counter: `mypiano.elasticsearch.search.empty_hits`
  - fallback counter: `mypiano.elasticsearch.search.fallbacks`
  - indexing counter: `mypiano.elasticsearch.indexing.requests`
- `ElasticSearchInstance`가 검색/자동완성 timeout 응답을 명시적 `ElasticSearchException`으로 처리하고 timeout/error/success/empty-hit 메트릭을 기록합니다.
- SheetPost ES 검색 실패 시 `SheetPostApplicationService`가 DB 검색으로 fallback하도록 변경했습니다.
- SheetPost async indexing 성공/실패 메트릭을 추가했습니다.

## Implementation intent
Elasticsearch timeout/error가 발생해도 사용자-facing SheetPost 검색 API가 전체 실패로 번지지 않게 하고, 운영자가 latency/error/fallback/empty-hit/indexing 상태를 관측할 수 있게 합니다.

## Implementation approach
- ES HTTP client에 connect/socket/connection-request timeout을 설정합니다.
- ES 검색 호출 전 timer sample을 시작하고, 응답/예외 결과에 따라 success/timeout/error outcome tag로 timer와 counter를 기록합니다.
- ES 응답이 `timedOut=true`이면 검색 실패로 간주해 `ElasticSearchException`을 던집니다.
- `SheetPostApplicationService.loadSheetPostListPayloadEs(...)`는 `ElasticSearchException`을 catch해 동일 조건의 DB 검색으로 fallback합니다.
- fallback raw query에는 `es-fallback[...]` marker를 남겨 검색 로그에서도 fallback 여부를 구분할 수 있게 했습니다.

## Verification method
- ES timed-out response가 `ElasticSearchException`으로 변환되고 timeout metric이 증가하는 단위 테스트를 추가했습니다.
- SheetPost ES 검색 실패 시 DB 검색으로 fallback하고 fallback metric이 증가하는 단위 테스트를 추가했습니다.
- 기존 infra 의존 전체 build는 별도로 실행해 환경 실패 원인을 확인했습니다.

## 테스트/검증 결과
- PASS: `JAVA_HOME=/home/jiwoo/.sdkman/candidates/java/current PATH=/home/jiwoo/.sdkman/candidates/java/current/bin:$PATH bash ./gradlew test --tests 'com.omegafrog.My.piano.app.external.elasticsearch.ElasticSearchInstanceResilienceTest' --tests 'com.omegafrog.My.piano.app.web.service.SheetPostApplicationServiceSearchFallbackTest' -x ensureTestInfra`
- FAIL: `JAVA_HOME=/home/jiwoo/.sdkman/candidates/java/current PATH=/home/jiwoo/.sdkman/candidates/java/current/bin:$PATH bash ./gradlew build`
  - `ensureTestInfra`에서 WSL 환경에 `docker-compose`가 없어 실패했습니다.
- FAIL: `JAVA_HOME=/home/jiwoo/.sdkman/candidates/java/current PATH=/home/jiwoo/.sdkman/candidates/java/current/bin:$PATH bash ./gradlew build -x ensureTestInfra`
  - 기존 Spring 통합/Repository 테스트가 MySQL 연결 실패 및 캐시 설정 실패로 실패했습니다.

## 영향 범위 및 리스크
- 영향 범위는 Elasticsearch client 설정, SheetPost ES 검색/자동완성, SheetPost async indexing 메트릭입니다.
- ES 장애 시 검색 결과는 DB fallback 결과로 제공되어 relevance scoring과 결과 정렬이 ES와 다를 수 있습니다.
- timeout 기본값은 보수적으로 낮게 설정했으며 운영 환경에서 필요하면 `elasticsearch.*TimeoutMillis`로 조정할 수 있습니다.
